### PR TITLE
Convert SBR multi-node tests to async

### DIFF
--- a/src/core/Akka.Cluster.Tests.MultiNode/SBR/DownAllIndirectlyConnected5NodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SBR/DownAllIndirectlyConnected5NodeSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.MultiNode.TestAdapter;
@@ -74,12 +75,12 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
         }
 
         [MultiNodeFact]
-        public void DownAllIndirectlyConnected5NodeSpecTests()
+        public async Task DownAllIndirectlyConnected5NodeSpecTests()
         {
-            A_5_node_cluster_with_keep_one_indirectly_connected_off_should_down_all_when_indirectly_connected_combined_with_clean_partition();
+            await A_5_node_cluster_with_keep_one_indirectly_connected_off_should_down_all_when_indirectly_connected_combined_with_clean_partition();
         }
 
-        public void A_5_node_cluster_with_keep_one_indirectly_connected_off_should_down_all_when_indirectly_connected_combined_with_clean_partition()
+        public async Task A_5_node_cluster_with_keep_one_indirectly_connected_off_should_down_all_when_indirectly_connected_combined_with_clean_partition()
         {
             var cluster = Cluster.Get(Sys);
 
@@ -87,7 +88,7 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             {
                 cluster.Join(cluster.SelfAddress);
             }, _config.Node1);
-            EnterBarrier("node1 joined");
+            await EnterBarrierAsync("node1 joined");
             RunOn(() =>
             {
                 cluster.Join(Node(_config.Node1).Address);
@@ -103,26 +104,26 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                     }
                 });
             });
-            EnterBarrier("Cluster formed");
+            await EnterBarrierAsync("Cluster formed");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
 
                 foreach (var x in new[] { _config.Node1, _config.Node2, _config.Node3 })
                 {
                     foreach (var y in new[] { _config.Node4, _config.Node5 })
                     {
-                        TestConductor.Blackhole(x, y, ThrottleTransportAdapter.Direction.Both).Wait();
+                        await TestConductor.BlackholeAsync(x, y, ThrottleTransportAdapter.Direction.Both);
                     }
                 }
             }, _config.Node1);
-            EnterBarrier("blackholed-clean-partition");
+            await EnterBarrierAsync("blackholed-clean-partition");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                TestConductor.Blackhole(_config.Node2, _config.Node3, ThrottleTransportAdapter.Direction.Both).Wait();
+                await TestConductor.BlackholeAsync(_config.Node2, _config.Node3, ThrottleTransportAdapter.Direction.Both);
             }, _config.Node1);
-            EnterBarrier("blackholed-indirectly-connected");
+            await EnterBarrierAsync("blackholed-indirectly-connected");
 
             Within(TimeSpan.FromSeconds(10), () =>
             {
@@ -146,7 +147,7 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                     }, _config.Node4, _config.Node5);
                 });
             });
-            EnterBarrier("unreachable");
+            await EnterBarrierAsync("unreachable");
 
             RunOn(() =>
             {
@@ -169,7 +170,7 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                 AwaitCondition(() => cluster.IsTerminated, max: TimeSpan.FromSeconds(15));
             }, _config.Node2, _config.Node3, _config.Node4, _config.Node5);
 
-            EnterBarrier("done");
+            await EnterBarrierAsync("done");
         }
     }
 }

--- a/src/core/Akka.Cluster.Tests.MultiNode/SBR/DownAllIndirectlyConnected5NodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SBR/DownAllIndirectlyConnected5NodeSpec.cs
@@ -149,11 +149,11 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             });
             await EnterBarrierAsync("unreachable");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                Within(TimeSpan.FromSeconds(15), () =>
+                await WithinAsync(TimeSpan.FromSeconds(15), async () =>
                 {
-                    AwaitAssert(() =>
+                    await AwaitAssertAsync(() =>
                     {
                         cluster.State.Members.Select(i => i.Address).Should().BeEquivalentTo(Node(_config.Node1).Address);
                         foreach (var m in cluster.State.Members)
@@ -164,10 +164,10 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                 });
             }, _config.Node1);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 // downed
-                AwaitCondition(() => cluster.IsTerminated, max: TimeSpan.FromSeconds(15));
+                await AwaitConditionAsync(() => Task.FromResult(cluster.IsTerminated), max: TimeSpan.FromSeconds(15));
             }, _config.Node2, _config.Node3, _config.Node4, _config.Node5);
 
             await EnterBarrierAsync("done");

--- a/src/core/Akka.Cluster.Tests.MultiNode/SBR/DownAllUnstable5NodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SBR/DownAllUnstable5NodeSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.MultiNode.TestAdapter;
@@ -80,12 +81,12 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
         }
 
         [MultiNodeFact]
-        public void DownAllUnstable5NodeSpecTests()
+        public async Task DownAllUnstable5NodeSpecTests()
         {
-            A_5_node_cluster_with_down_all_when_unstable_should_down_all_when_instability_continues();
+            await A_5_node_cluster_with_down_all_when_unstable_should_down_all_when_instability_continues();
         }
 
-        public void A_5_node_cluster_with_down_all_when_unstable_should_down_all_when_instability_continues()
+        public async Task A_5_node_cluster_with_down_all_when_unstable_should_down_all_when_instability_continues()
         {
             var cluster = Cluster.Get(Sys);
 
@@ -93,7 +94,7 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             {
                 cluster.Join(cluster.SelfAddress);
             }, _config.Node1);
-            EnterBarrier("node1 joined");
+            await EnterBarrierAsync("node1 joined");
             RunOn(() =>
             {
                 cluster.Join(Node(_config.Node1).Address);
@@ -110,23 +111,23 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                 });
             });
 
-            EnterBarrier("Cluster formed");
+            await EnterBarrierAsync("Cluster formed");
 
             // acceptable-heartbeat-pause = 3s
             // stable-after = 10s
             // down-all-when-unstable = 7s
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 foreach (var x in new[] { _config.Node1, _config.Node2, _config.Node3 })
                 {
                     foreach (var y in new[] { _config.Node4, _config.Node5 })
                     {
-                        TestConductor.Blackhole(x, y, ThrottleTransportAdapter.Direction.Both).Wait();
+                        await TestConductor.BlackholeAsync(x, y, ThrottleTransportAdapter.Direction.Both);
                     }
                 }
             }, _config.Node1);
-            EnterBarrier("blackholed-clean-partition");
+            await EnterBarrierAsync("blackholed-clean-partition");
 
             Within(TimeSpan.FromSeconds(10), () =>
             {
@@ -142,36 +143,36 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                     }, _config.Node4, _config.Node5);
                 });
             });
-            EnterBarrier("unreachable-clean-partition");
+            await EnterBarrierAsync("unreachable-clean-partition");
 
             // no decision yet
-            Thread.Sleep(2000);
+            await Task.Delay(2000);
             cluster.State.Members.Count.Should().Be(5);
             foreach (var m in cluster.State.Members)
             {
                 m.Status.Should().Be(MemberStatus.Up);
             }
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                TestConductor.Blackhole(_config.Node2, _config.Node3, ThrottleTransportAdapter.Direction.Both).Wait();
+                await TestConductor.BlackholeAsync(_config.Node2, _config.Node3, ThrottleTransportAdapter.Direction.Both);
             }, _config.Node1);
-            EnterBarrier("blackhole-2");
+            await EnterBarrierAsync("blackhole-2");
             // then it takes about 5 seconds for failure detector to observe that
-            Thread.Sleep(7000);
+            await Task.Delay(7000);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                TestConductor.PassThrough(_config.Node2, _config.Node3, ThrottleTransportAdapter.Direction.Both).Wait();
+                await TestConductor.PassThroughAsync(_config.Node2, _config.Node3, ThrottleTransportAdapter.Direction.Both);
             }, _config.Node1);
-            EnterBarrier("passThrough-2");
+            await EnterBarrierAsync("passThrough-2");
 
             // now it should have been unstable for more than 17 seconds
 
             // all downed
             AwaitCondition(() => cluster.IsTerminated, max: TimeSpan.FromSeconds(15));
 
-            EnterBarrier("done");
+            await EnterBarrierAsync("done");
         }
     }
 }

--- a/src/core/Akka.Cluster.Tests.MultiNode/SBR/DownAllUnstable5NodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SBR/DownAllUnstable5NodeSpec.cs
@@ -99,9 +99,9 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             {
                 cluster.Join(Node(_config.Node1).Address);
             }, _config.Node2, _config.Node3, _config.Node4, _config.Node5);
-            Within(TimeSpan.FromSeconds(10), () =>
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     cluster.State.Members.Count.Should().Be(5);
                     foreach (var m in cluster.State.Members)
@@ -129,9 +129,9 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             }, _config.Node1);
             await EnterBarrierAsync("blackholed-clean-partition");
 
-            Within(TimeSpan.FromSeconds(10), () =>
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     RunOn(() =>
                     {
@@ -170,7 +170,7 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             // now it should have been unstable for more than 17 seconds
 
             // all downed
-            AwaitCondition(() => cluster.IsTerminated, max: TimeSpan.FromSeconds(15));
+            await AwaitConditionAsync(() => Task.FromResult(cluster.IsTerminated), max: TimeSpan.FromSeconds(15));
 
             await EnterBarrierAsync("done");
         }

--- a/src/core/Akka.Cluster.Tests.MultiNode/SBR/IndirectlyConnected3NodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SBR/IndirectlyConnected3NodeSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.MultiNode.TestAdapter;
@@ -68,12 +69,12 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
         }
 
         [MultiNodeFact]
-        public void IndirectlyConnected3NodeSpecTests()
+        public async Task IndirectlyConnected3NodeSpecTests()
         {
-            A_3_node_cluster_should_avoid_a_split_brain_when_two_unreachable_but_can_talk_via_third();
+            await A_3_node_cluster_should_avoid_a_split_brain_when_two_unreachable_but_can_talk_via_third();
         }
 
-        public void A_3_node_cluster_should_avoid_a_split_brain_when_two_unreachable_but_can_talk_via_third()
+        public async Task A_3_node_cluster_should_avoid_a_split_brain_when_two_unreachable_but_can_talk_via_third()
         {
             var cluster = Cluster.Get(Sys);
 
@@ -81,7 +82,7 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             {
                 cluster.Join(cluster.SelfAddress);
             }, _config.Node1);
-            EnterBarrier("node1 joined");
+            await EnterBarrierAsync("node1 joined");
             RunOn(() =>
             {
                 cluster.Join(Node(_config.Node1).Address);
@@ -97,13 +98,13 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                     }
                 });
             });
-            EnterBarrier("Cluster formed");
+            await EnterBarrierAsync("Cluster formed");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                TestConductor.Blackhole(_config.Node2, _config.Node3, ThrottleTransportAdapter.Direction.Both).Wait();
+                await TestConductor.BlackholeAsync(_config.Node2, _config.Node3, ThrottleTransportAdapter.Direction.Both);
             }, _config.Node1);
-            EnterBarrier("Blackholed");
+            await EnterBarrierAsync("Blackholed");
 
             Within(TimeSpan.FromSeconds(10), () =>
             {
@@ -123,7 +124,7 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                     }, _config.Node1);
                 });
             });
-            EnterBarrier("unreachable");
+            await EnterBarrierAsync("unreachable");
 
             RunOn(() =>
             {
@@ -146,7 +147,7 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                 AwaitCondition(() => cluster.IsTerminated, max: TimeSpan.FromSeconds(15));
             }, _config.Node2, _config.Node3);
 
-            EnterBarrier("done");
+            await EnterBarrierAsync("done");
         }
     }
 }

--- a/src/core/Akka.Cluster.Tests.MultiNode/SBR/IndirectlyConnected3NodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SBR/IndirectlyConnected3NodeSpec.cs
@@ -87,9 +87,9 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             {
                 cluster.Join(Node(_config.Node1).Address);
             }, _config.Node2, _config.Node3);
-            Within(TimeSpan.FromSeconds(10), () =>
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     cluster.State.Members.Count.Should().Be(3);
                     foreach (var m in cluster.State.Members)
@@ -106,9 +106,9 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             }, _config.Node1);
             await EnterBarrierAsync("Blackholed");
 
-            Within(TimeSpan.FromSeconds(10), () =>
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     RunOn(() =>
                     {
@@ -126,11 +126,11 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             });
             await EnterBarrierAsync("unreachable");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                Within(TimeSpan.FromSeconds(15), () =>
+                await WithinAsync(TimeSpan.FromSeconds(15), async () =>
                 {
-                    AwaitAssert(() =>
+                    await AwaitAssertAsync(() =>
                     {
                         cluster.State.Members.Select(i => i.Address).Should().BeEquivalentTo(Node(_config.Node1).Address);
                         foreach (var m in cluster.State.Members)
@@ -141,10 +141,10 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                 });
             }, _config.Node1);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 // downed
-                AwaitCondition(() => cluster.IsTerminated, max: TimeSpan.FromSeconds(15));
+                await AwaitConditionAsync(() => Task.FromResult(cluster.IsTerminated), max: TimeSpan.FromSeconds(15));
             }, _config.Node2, _config.Node3);
 
             await EnterBarrierAsync("done");

--- a/src/core/Akka.Cluster.Tests.MultiNode/SBR/IndirectlyConnected5NodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SBR/IndirectlyConnected5NodeSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.MultiNode.TestAdapter;
@@ -73,12 +74,12 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
         }
 
         [MultiNodeFact]
-        public void IndirectlyConnected5NodeSpecTests()
+        public async Task IndirectlyConnected5NodeSpecTests()
         {
-            A_5_node_cluster_should_avoid_a_split_brain_when_indirectly_connected_combined_with_clean_partition();
+            await A_5_node_cluster_should_avoid_a_split_brain_when_indirectly_connected_combined_with_clean_partition();
         }
 
-        public void A_5_node_cluster_should_avoid_a_split_brain_when_indirectly_connected_combined_with_clean_partition()
+        public async Task A_5_node_cluster_should_avoid_a_split_brain_when_indirectly_connected_combined_with_clean_partition()
         {
             var cluster = Cluster.Get(Sys);
 
@@ -86,7 +87,7 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             {
                 cluster.Join(cluster.SelfAddress);
             }, _config.Node1);
-            EnterBarrier("node1 joined");
+            await EnterBarrierAsync("node1 joined");
             RunOn(() =>
             {
                 cluster.Join(Node(_config.Node1).Address);
@@ -102,26 +103,26 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                     }
                 });
             });
-            EnterBarrier("Cluster formed");
+            await EnterBarrierAsync("Cluster formed");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 foreach (var x in new[] { _config.Node1, _config.Node2, _config.Node3 })
                 {
                     foreach (var y in new[] { _config.Node4, _config.Node5 })
                     {
-                        TestConductor.Blackhole(x, y, ThrottleTransportAdapter.Direction.Both).Wait();
+                        await TestConductor.BlackholeAsync(x, y, ThrottleTransportAdapter.Direction.Both);
                     }
                 }
 
             }, _config.Node1);
-            EnterBarrier("blackholed-clean-partition");
+            await EnterBarrierAsync("blackholed-clean-partition");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                TestConductor.Blackhole(_config.Node2, _config.Node3, ThrottleTransportAdapter.Direction.Both).Wait();
+                await TestConductor.BlackholeAsync(_config.Node2, _config.Node3, ThrottleTransportAdapter.Direction.Both);
             }, _config.Node1);
-            EnterBarrier("blackholed-indirectly-connected");
+            await EnterBarrierAsync("blackholed-indirectly-connected");
 
             Within(TimeSpan.FromSeconds(10), () =>
             {
@@ -145,7 +146,7 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                     }, _config.Node4, _config.Node5);
                 });
             });
-            EnterBarrier("unreachable");
+            await EnterBarrierAsync("unreachable");
 
             RunOn(() =>
             {
@@ -168,7 +169,7 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                 AwaitCondition(() => cluster.IsTerminated, max: TimeSpan.FromSeconds(15));
             }, _config.Node2, _config.Node3, _config.Node4, _config.Node5);
 
-            EnterBarrier("done");
+            await EnterBarrierAsync("done");
         }
     }
 }

--- a/src/core/Akka.Cluster.Tests.MultiNode/SBR/IndirectlyConnected5NodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SBR/IndirectlyConnected5NodeSpec.cs
@@ -92,9 +92,9 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             {
                 cluster.Join(Node(_config.Node1).Address);
             }, _config.Node2, _config.Node3, _config.Node4, _config.Node5);
-            Within(TimeSpan.FromSeconds(10), () =>
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     cluster.State.Members.Count.Should().Be(5);
                     foreach (var m in cluster.State.Members)
@@ -124,9 +124,9 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             }, _config.Node1);
             await EnterBarrierAsync("blackholed-indirectly-connected");
 
-            Within(TimeSpan.FromSeconds(10), () =>
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     RunOn(() =>
                     {
@@ -148,11 +148,11 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             });
             await EnterBarrierAsync("unreachable");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                Within(TimeSpan.FromSeconds(15), () =>
+                await WithinAsync(TimeSpan.FromSeconds(15), async () =>
                 {
-                    AwaitAssert(() =>
+                    await AwaitAssertAsync(() =>
                     {
                         cluster.State.Members.Select(i => i.Address).Should().BeEquivalentTo(Node(_config.Node1).Address);
                         foreach (var m in cluster.State.Members)
@@ -163,10 +163,10 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                 });
             }, _config.Node1);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 // downed
-                AwaitCondition(() => cluster.IsTerminated, max: TimeSpan.FromSeconds(15));
+                await AwaitConditionAsync(() => Task.FromResult(cluster.IsTerminated), max: TimeSpan.FromSeconds(15));
             }, _config.Node2, _config.Node3, _config.Node4, _config.Node5);
 
             await EnterBarrierAsync("done");

--- a/src/core/Akka.Cluster.Tests.MultiNode/SBR/LeaseMajority5NodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SBR/LeaseMajority5NodeSpec.cs
@@ -124,20 +124,20 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
 
 
         [MultiNodeFact]
-        public void LeaseMajority5NodeSpecTests()
+        public async Task LeaseMajority5NodeSpecTests()
         {
-            LeaseMajority_in_a_5_node_cluster_should_setup_cluster();
-            LeaseMajority_in_a_5_node_cluster_should_keep_the_side_that_can_acquire_the_lease();
-            LeaseMajority_in_a_5_node_cluster_should_keep_the_side_that_can_acquire_the_lease_round_2();
+            await LeaseMajority_in_a_5_node_cluster_should_setup_cluster();
+            await LeaseMajority_in_a_5_node_cluster_should_keep_the_side_that_can_acquire_the_lease();
+            await LeaseMajority_in_a_5_node_cluster_should_keep_the_side_that_can_acquire_the_lease_round_2();
         }
 
-        public void LeaseMajority_in_a_5_node_cluster_should_setup_cluster()
+        public async Task LeaseMajority_in_a_5_node_cluster_should_setup_cluster()
         {
             RunOn(() =>
             {
                 Cluster.Join(Cluster.SelfAddress);
             }, _config.Node1);
-            EnterBarrier("node1 joined");
+            await EnterBarrierAsync("node1 joined");
             RunOn(() =>
             {
                 Cluster.Join(Node(_config.Node1).Address);
@@ -153,10 +153,10 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                     }
                 });
             });
-            EnterBarrier("Cluster formed");
+            await EnterBarrierAsync("Cluster formed");
         }
 
-        public void LeaseMajority_in_a_5_node_cluster_should_keep_the_side_that_can_acquire_the_lease()
+        public async Task LeaseMajority_in_a_5_node_cluster_should_keep_the_side_that_can_acquire_the_lease()
         {
             var lease = TestLeaseExt.Get(Sys).GetTestLease(testLeaseName);
             var leaseProbe = lease.Probe;
@@ -169,18 +169,18 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             {
                 lease.SetNextAcquireResult(Task.FromResult(false));
             }, _config.Node4, _config.Node5);
-            EnterBarrier("lease-in-place");
-            RunOn(() =>
+            await EnterBarrierAsync("lease-in-place");
+            await RunOnAsync(async () =>
             {
                 foreach (var x in new[] { _config.Node1, _config.Node2, _config.Node3 })
                 {
                     foreach (var y in new[] { _config.Node4, _config.Node5 })
                     {
-                        TestConductor.Blackhole(x, y, ThrottleTransportAdapter.Direction.Both).Wait();
+                        await TestConductor.BlackholeAsync(x, y, ThrottleTransportAdapter.Direction.Both);
                     }
                 }
             }, _config.Node1);
-            EnterBarrier("blackholed-clean-partition");
+            await EnterBarrierAsync("blackholed-clean-partition");
 
             RunOn(() =>
             {
@@ -212,13 +212,13 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                     }, Leader(_config.Node4, _config.Node5));
                 });
             }, _config.Node4, _config.Node5);
-            EnterBarrier("downed-and-removed");
+            await EnterBarrierAsync("downed-and-removed");
             leaseProbe.ExpectNoMsg(TimeSpan.FromSeconds(1));
 
-            EnterBarrier("done-1");
+            await EnterBarrierAsync("done-1");
         }
 
-        public void LeaseMajority_in_a_5_node_cluster_should_keep_the_side_that_can_acquire_the_lease_round_2()
+        public async Task LeaseMajority_in_a_5_node_cluster_should_keep_the_side_that_can_acquire_the_lease_round_2()
         {
             var lease = TestLeaseExt.Get(Sys).GetTestLease(testLeaseName);
 
@@ -230,18 +230,18 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             {
                 lease.SetNextAcquireResult(Task.FromResult(false));
             }, _config.Node2, _config.Node3);
-            EnterBarrier("lease-in-place-2");
-            RunOn(() =>
+            await EnterBarrierAsync("lease-in-place-2");
+            await RunOnAsync(async () =>
             {
                 foreach (var x in new[] { _config.Node1 })
                 {
                     foreach (var y in new[] { _config.Node2, _config.Node3 })
                     {
-                        TestConductor.Blackhole(x, y, ThrottleTransportAdapter.Direction.Both).Wait();
+                        await TestConductor.BlackholeAsync(x, y, ThrottleTransportAdapter.Direction.Both);
                     }
                 }
             }, _config.Node1);
-            EnterBarrier("blackholed-clean-partition-2");
+            await EnterBarrierAsync("blackholed-clean-partition-2");
 
             RunOn(() =>
             {
@@ -264,7 +264,7 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                 });
             }, _config.Node2, _config.Node3);
 
-            EnterBarrier("done-2");
+            await EnterBarrierAsync("done-2");
         }
     }
 }

--- a/src/core/Akka.Cluster.Tests.MultiNode/SBR/LeaseMajority5NodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SBR/LeaseMajority5NodeSpec.cs
@@ -142,9 +142,9 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             {
                 Cluster.Join(Node(_config.Node1).Address);
             }, _config.Node2, _config.Node3, _config.Node4, _config.Node5);
-            Within(TimeSpan.FromSeconds(10), () =>
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.State.Members.Count.Should().Be(5);
                     foreach (var m in Cluster.State.Members)
@@ -182,11 +182,11 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             }, _config.Node1);
             await EnterBarrierAsync("blackholed-clean-partition");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                Within(TimeSpan.FromSeconds(20), () =>
+                await WithinAsync(TimeSpan.FromSeconds(20), async () =>
                 {
-                    AwaitAssert(() =>
+                    await AwaitAssertAsync(() =>
                     {
                         Cluster.State.Members.Count.Should().Be(3);
                     });
@@ -198,11 +198,11 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
                     leaseProbe.ExpectMsg<TestLease.ReleaseReq>(TimeSpan.FromSeconds(14));
                 }, Leader(_config.Node1, _config.Node2, _config.Node3));
             }, _config.Node1, _config.Node2, _config.Node3);
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                Within(TimeSpan.FromSeconds(20), () =>
+                await WithinAsync(TimeSpan.FromSeconds(20), async () =>
                 {
-                    AwaitAssert(() =>
+                    await AwaitAssertAsync(() =>
                     {
                         Cluster.IsTerminated.Should().BeTrue();
                     });
@@ -243,21 +243,21 @@ namespace Akka.Cluster.Tests.MultiNode.SBR
             }, _config.Node1);
             await EnterBarrierAsync("blackholed-clean-partition-2");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                Within(TimeSpan.FromSeconds(20), () =>
+                await WithinAsync(TimeSpan.FromSeconds(20), async () =>
                 {
-                    AwaitAssert(() =>
+                    await AwaitAssertAsync(() =>
                     {
                         Cluster.State.Members.Count.Should().Be(1);
                     });
                 });
             }, _config.Node1);
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                Within(TimeSpan.FromSeconds(20), () =>
+                await WithinAsync(TimeSpan.FromSeconds(20), async () =>
                 {
-                    AwaitAssert(() =>
+                    await AwaitAssertAsync(() =>
                     {
                         Cluster.IsTerminated.Should().BeTrue();
                     });


### PR DESCRIPTION
## Summary
This PR migrates the Split Brain Resolver (SBR) multi-node tests from blocking synchronous calls to async/await patterns to prevent thread pool starvation and test timeouts in CI environments.

## Changes
Converted the following test specs to async:
- `DownAllIndirectlyConnected5NodeSpec`
- `DownAllUnstable5NodeSpec`  
- `IndirectlyConnected3NodeSpec`
- `IndirectlyConnected5NodeSpec`
- `LeaseMajority5NodeSpec`

## Migration Details
- Converted test methods from `void` to `async Task`
- Replaced `TestConductor.Blackhole().Wait()` with `await TestConductor.BlackholeAsync()`
- Replaced `TestConductor.PassThrough().Wait()` with `await TestConductor.PassThroughAsync()`
- Replaced `EnterBarrier()` with `await EnterBarrierAsync()`
- Replaced `Thread.Sleep()` with `await Task.Delay()`
- Used `RunOnAsync` with async lambdas for TestConductor operations
- Added `using System.Threading.Tasks` to all modified files

## Test Plan
- [x] Built the solution successfully
- [x] Ran IndirectlyConnected3NodeSpec - all 3 tests passed
- [x] Ran LeaseMajority5NodeSpec - all 5 tests passed
- [x] No functional changes to test logic, only async migration

## Context
This is part of the ongoing effort to migrate multi-node tests to async patterns as documented in `MULTINODE_TEST_ASYNC_MIGRATION.md`. These changes improve test reliability by preventing thread pool starvation that was causing 20+ second timeout failures in CI environments.