### PR TITLE
perf(io): remove Akka.IO TCP read + write pumps (DRAFT — concurrent-close deadlock under review)

### DIFF
--- a/src/core/Akka.Tests/IO/TcpConcurrentCloseSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpConcurrentCloseSpec.cs
@@ -1,0 +1,279 @@
+//-----------------------------------------------------------------------
+// <copyright file="TcpConcurrentCloseSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.IO;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Tests.IO
+{
+    /// <summary>
+    /// Regression coverage for the <b>concurrent-close</b> read-gate blind spot in
+    /// <see cref="TcpTransportConnection"/>.
+    /// <para>
+    /// The inbound side is consumer-driven (no read pump): the owning <see cref="TcpConnection"/>
+    /// actor keeps a <c>ReadAsync</c> in flight on the transport's <c>StreamPipeReader</c>, wrapped
+    /// in a <c>ReadGate</c>. The gate serializes <c>Complete()</c> against a read that is still
+    /// <em>parked inside</em> the inner stream read (that window is covered by
+    /// <see cref="TcpGracefulCloseRaceSpec"/>). But it used to stop tracking the read the moment
+    /// <c>_inner.ReadAsync</c> RETURNED — clearing <c>_inflightRead = null</c> in its finally —
+    /// while the consumer kept using the returned <c>ReadResult.Buffer</c> OUTSIDE the gate
+    /// (<c>new byte[buffer.Length]; buffer.CopyTo(array); reader.AdvanceTo(buffer.End)</c>).
+    /// </para>
+    /// <para>
+    /// Under a concurrent close: <c>CloseAsync → QuiesceAndCompleteAsync</c> sees
+    /// <c>_inflightRead == null</c> → calls <c>_inner.Complete()</c> → the StreamPipeReader RECYCLES
+    /// the BufferSegments the consumer is mid-<c>CopyTo</c> on → <see cref="ArgumentOutOfRangeException"/>
+    /// from <c>BuffersExtensions.CopyTo</c>. That fault was NOT classified as an own-shutdown fault,
+    /// so it became an <c>IoTaskFailed</c> → <c>DoCloseConnection(ErrorClosed(...))</c>. The peer only
+    /// handles <see cref="Tcp.Closed"/>; <see cref="Tcp.ErrorClosed"/> is a sibling
+    /// <see cref="Tcp.ConnectionClosed"/> and <see cref="Tcp.ConnectionClosed"/> implements
+    /// <see cref="Akka.Event.IDeadLetterSuppression"/> → the message is dropped SILENTLY → that
+    /// connection never reports closed → a coordinating Ask would hang forever. (Reproduced by
+    /// <c>TcpOperationsBenchmarks</c> hanging at ClientsCount=10/30; ClientsCount=1 was fine.)
+    /// </para>
+    /// <para>
+    /// The single-exchange close coverage in the other specs never lands inside this post-return
+    /// window, so it misses the bug. This spec pins it: open many connections each running a
+    /// continuous echo flood (so there is almost always an inbound read that has just RETURNED and
+    /// is mid-<c>CopyTo</c> when close lands), then <see cref="Tcp.Close"/> them all at ~the same
+    /// instant. Every close must be a clean <see cref="Tcp.Closed"/> on the initiator — never an
+    /// <see cref="Tcp.ErrorClosed"/> (how the corruption surfaces) — and all must complete within a
+    /// short timeout (no silent hang). It FAILS on the buggy code (ErrorClosed and/or a hung
+    /// connection) and PASSES once the gate copies the bytes out internally before clearing
+    /// <c>_inflightRead</c>.
+    /// </para>
+    /// </summary>
+    public class TcpConcurrentCloseSpec : AkkaSpec
+    {
+        // Sized so a read commonly returns a multi-segment buffer (wider CopyTo window) and so the
+        // flood keeps inbound data continuously available across all connections.
+        private const int PayloadSize = 16 * 1024;
+
+        public TcpConcurrentCloseSpec(ITestOutputHelper output)
+            : base("akka.loglevel = INFO\nakka.log-dead-letters = off", output: output)
+        {
+        }
+
+        /// <summary>
+        /// Open N connections, run a continuous echo flood on each, then close them ALL concurrently
+        /// while data is in flight. Asserts every initiator reports a clean <see cref="Tcp.Closed"/>
+        /// (never <see cref="Tcp.ErrorClosed"/> / <see cref="ArgumentOutOfRangeException"/>) and that
+        /// every close completes within a short timeout (no silent hang).
+        /// </summary>
+        [Fact]
+        public async Task Concurrent_Close_under_inbound_flood_should_never_ErrorClose_or_hang()
+        {
+            const int connectionCount = 30;
+            // Several rounds so we get many shots at the narrow post-return CopyTo window. The buggy
+            // code corrupts at least one connection within a couple of rounds; the fix is clean on
+            // every round.
+            const int rounds = 8;
+
+            // Bind a flooding echo server once and reuse across rounds: it echoes everything back so
+            // the client side has a steady stream of inbound bytes right up to close time.
+            var server = Sys.ActorOf(Props.Create(() => new FloodServer(PayloadSize)), "flood-server");
+            var boundProbe = CreateTestProbe("bound");
+            server.Tell(new SubscribeBound(boundProbe.Ref));
+            var bound = await boundProbe.ExpectMsgAsync<Tcp.Bound>(TimeSpan.FromSeconds(10));
+            var endpoint = (IPEndPoint)bound.LocalAddress;
+
+            for (var round = 0; round < rounds; round++)
+                await RunRoundAsync(endpoint, connectionCount, round);
+        }
+
+        private async Task RunRoundAsync(IPEndPoint endpoint, int connectionCount, int round)
+        {
+            // Spin up N flood clients. Each reports Closed (or the lack of it) via its own TCS.
+            var clients = new List<(IActorRef Actor, TaskCompletionSource<Tcp.ConnectionClosed> Closed)>(connectionCount);
+            for (var i = 0; i < connectionCount; i++)
+            {
+                var closed = new TaskCompletionSource<Tcp.ConnectionClosed>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                var actor = Sys.ActorOf(Props.Create(() => new FloodClient(endpoint, PayloadSize, closed)),
+                    $"flood-client-{round}-{i}");
+                clients.Add((actor, closed));
+            }
+
+            // Wait until every client is connected AND has data flowing both ways, so a close will
+            // land inside the post-return CopyTo window rather than before any data exists.
+            var primed = clients.Select(c => WaitPrimedAsync(c.Actor)).ToArray();
+            await Task.WhenAll(primed).WaitAsync(TimeSpan.FromSeconds(30));
+
+            // Let the flood build for a beat so there is reliably an inbound read mid-CopyTo on each
+            // connection when the closes land.
+            await Task.Delay(40);
+
+            // Close every connection at ~the same instant, mid-flood. The tight loop packs the
+            // closes into the narrow post-return window across many connections at once.
+            foreach (var c in clients)
+                c.Actor.Tell(Close.Instance);
+
+            // Every initiator must observe a clean Closed within a short budget. On the buggy code a
+            // corrupted connection either surfaces ErrorClosed or silently drops it (the message is
+            // IDeadLetterSuppression) and never reports closed — which this WaitAsync timeout turns
+            // into a hard, deterministic failure instead of a hang.
+            var results = await Task.WhenAll(clients.Select(c => c.Closed.Task))
+                .WaitAsync(TimeSpan.FromSeconds(30));
+
+            for (var i = 0; i < results.Length; i++)
+            {
+                results[i].Should().BeOfType<Tcp.Closed>(
+                    $"connection {i} (round {round}) must close cleanly under concurrent close, was: {Describe(results[i])}");
+            }
+
+            // Tear down this round's clients before the next.
+            foreach (var c in clients)
+                Sys.Stop(c.Actor);
+        }
+
+        private static async Task WaitPrimedAsync(IActorRef client)
+        {
+            // Poll the client's "primed" flag via Ask. Cheap and avoids extra plumbing.
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(25);
+            while (DateTime.UtcNow < deadline)
+            {
+                var primed = await client.Ask<bool>(IsPrimed.Instance, TimeSpan.FromSeconds(5));
+                if (primed)
+                    return;
+                await Task.Delay(20);
+            }
+
+            throw new TimeoutException("flood client never primed");
+        }
+
+        private static string Describe(Tcp.ConnectionClosed closed)
+            => closed is Tcp.ErrorClosed err
+                ? $"ErrorClosed(\"{err.Cause}\")"
+                : closed.GetType().Name;
+
+        private sealed class SubscribeBound
+        {
+            public SubscribeBound(IActorRef subscriber) => Subscriber = subscriber;
+            public IActorRef Subscriber { get; }
+        }
+
+        private sealed class IsPrimed
+        {
+            public static readonly IsPrimed Instance = new();
+            private IsPrimed() { }
+        }
+
+        private sealed class Close
+        {
+            public static readonly Close Instance = new();
+            private Close() { }
+        }
+
+        /// <summary>
+        /// Binds and, for each accepted connection, spins up a connection actor that echoes
+        /// everything it receives straight back — keeping the client side flooded with inbound data.
+        /// </summary>
+        private sealed class FloodServer : ReceiveActor
+        {
+            private IActorRef _subscriber = ActorRefs.Nobody;
+            private Tcp.Bound _bound;
+
+            public FloodServer(int payloadSize)
+            {
+                Context.System.Tcp().Tell(new Tcp.Bind(Self, new IPEndPoint(IPAddress.Loopback, 0)));
+
+                Receive<SubscribeBound>(sub =>
+                {
+                    _subscriber = sub.Subscriber;
+                    if (_bound != null)
+                        _subscriber.Tell(_bound);
+                });
+                Receive<Tcp.Bound>(b =>
+                {
+                    _bound = b;
+                    if (!_subscriber.IsNobody())
+                        _subscriber.Tell(b);
+                });
+                Receive<Tcp.Connected>(_ =>
+                {
+                    var conn = Context.ActorOf(Props.Create(() => new FloodServerConnection(Sender)));
+                    Sender.Tell(new Tcp.Register(conn));
+                });
+            }
+        }
+
+        private sealed class FloodServerConnection : ReceiveActor
+        {
+            public FloodServerConnection(IActorRef connection)
+            {
+                // Pure echo: bounce every received byte back. Combined with the client's continuous
+                // re-send this keeps inbound data flowing on BOTH sides at all times.
+                Receive<Tcp.Received>(r => connection.Tell(Tcp.Write.Create(r.Data)));
+                Receive<Tcp.ConnectionClosed>(_ => Context.Stop(Self));
+            }
+        }
+
+        /// <summary>
+        /// Connects, fires an opening burst, and keeps re-sending on every inbound chunk so there is
+        /// a continuous inbound flood. Reports the first <see cref="Tcp.ConnectionClosed"/> it sees
+        /// through the supplied TCS. Answers <see cref="IsPrimed"/> once data is flowing, and issues
+        /// <see cref="Tcp.Close"/> when told to <see cref="Close"/>.
+        /// </summary>
+        private sealed class FloodClient : ReceiveActor
+        {
+            private const int OpeningBurst = 8;
+
+            private readonly Tcp.WriteCommand _write;
+            private readonly TaskCompletionSource<Tcp.ConnectionClosed> _closed;
+            private IActorRef _connection = ActorRefs.Nobody;
+            private bool _primed;
+            private bool _closing;
+
+            public FloodClient(IPEndPoint endpoint, int payloadSize, TaskCompletionSource<Tcp.ConnectionClosed> closed)
+            {
+                _closed = closed;
+                var payload = new byte[payloadSize];
+                for (var i = 0; i < payload.Length; i++)
+                    payload[i] = (byte)(i & 0xFF);
+                _write = Tcp.Write.Create(payload.AsMemory());
+
+                Context.System.Tcp().Tell(new Tcp.Connect(endpoint, timeout: TimeSpan.FromSeconds(5)));
+
+                Receive<Tcp.Connected>(_ =>
+                {
+                    _connection = Sender;
+                    Sender.Tell(new Tcp.Register(Self));
+                    for (var i = 0; i < OpeningBurst; i++)
+                        _connection.Tell(_write);
+                });
+
+                Receive<Tcp.Received>(_ =>
+                {
+                    _primed = true;
+                    if (!_closing)
+                        _connection.Tell(_write); // keep the flood going
+                });
+
+                Receive<IsPrimed>(_ => Sender.Tell(_primed && !_connection.IsNobody()));
+
+                Receive<Close>(_ =>
+                {
+                    _closing = true;
+                    if (!_connection.IsNobody())
+                        _connection.Tell(Tcp.Close.Instance);
+                });
+
+                Receive<Tcp.ConnectionClosed>(c => _closed.TrySetResult(c));
+                Receive<Tcp.CommandFailed>(_ => { /* ignore write failures during teardown */ });
+            }
+        }
+    }
+}

--- a/src/core/Akka.Tests/IO/TcpConcurrentWriteSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpConcurrentWriteSpec.cs
@@ -1,0 +1,494 @@
+//-----------------------------------------------------------------------
+// <copyright file="TcpConcurrentWriteSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.IO;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Tests.IO
+{
+    /// <summary>
+    /// Liveness/correctness coverage for the write-side double-buffer in
+    /// <see cref="TcpTransportConnection"/>.
+    /// <para>
+    /// The single-connection batching gate (<c>TcpConnectionBatchingSpec</c>) drives only ONE
+    /// connection and never overlaps a graceful close with an in-flight write, so it cannot catch
+    /// the bug that the <c>TcpOperationsBenchmarks</c> macro-benchmark hangs on at
+    /// <c>ClientsCount &gt;= 10</c>: the double-buffer's backpressure flush completion runs OFF the
+    /// owning actor's thread and mutates the shared bookkeeping (<c>_inflightWrite</c>,
+    /// <c>_activeIdx</c>, the buffer slots) with no synchronization against either the actor's own
+    /// flushes or the close-time drain. Under concurrency that lets two
+    /// <see cref="Stream.WriteAsync(ReadOnlyMemory{byte},CancellationToken)"/> calls run on the
+    /// SAME stream at once — illegal on <see cref="NetworkStream"/> — which corrupts the shared
+    /// socket and surfaces as faulted writes, faulted reads, and ultimately a stalled connection.
+    /// </para>
+    /// </summary>
+    public class TcpConcurrentWriteSpec : AkkaSpec
+    {
+        public TcpConcurrentWriteSpec(ITestOutputHelper output)
+            : base("akka.loglevel = INFO\nakka.log-dead-letters = off", output: output)
+        {
+        }
+
+        /// <summary>
+        /// Deterministic regression guard for the core invariant: the double-buffer must never
+        /// have two stream writes outstanding at the same time, even when a graceful close races a
+        /// flush that arrived while a previous write was in flight.
+        /// <para>
+        /// Reproduction (single producer thread, exactly as the <c>TcpConnection</c> actor drives
+        /// it — fire-and-forget, discarding the flush result):
+        /// </para>
+        /// <list type="number">
+        /// <item>buffer batch A and flush → write #1 starts and is gated open (stays in flight);</item>
+        /// <item>buffer batch B and flush → a write is in flight, so B waits in the standby slot;</item>
+        /// <item>call <see cref="TcpTransportConnection.CloseAsync"/> (drain) while write #1 is still gated;</item>
+        /// <item>release write #1.</item>
+        /// </list>
+        /// On the buggy double-buffer the detached backpressure-flush continuation and the drain
+        /// both try to write batch B, so two writes overlap on the stream — the
+        /// <see cref="ConcurrencyDetectingStream"/> records the overlap and the test fails. With
+        /// the fix every write transition is serialized, so writes never overlap and all bytes
+        /// arrive in order.
+        /// </para>
+        /// </summary>
+        [Fact]
+        public async Task DoubleBuffer_should_never_overlap_stream_writes_when_close_races_an_inflight_write()
+        {
+            // The race is probabilistic per attempt (it needs the drain continuation and the
+            // backpressure-flush continuation to both observe the standby batch before either
+            // swaps the active slot), so we repeat the scenario many times. The buggy
+            // double-buffer overlaps/duplicates the standby write within a handful of attempts;
+            // the fix upholds the invariant on every one.
+            const int attempts = 120;
+            var a = MakeBytes('A', 8);
+            var b = MakeBytes('B', 16);
+            var expected = Concat(a, b);
+
+            for (var attempt = 0; attempt < attempts; attempt++)
+            {
+                using var socketPair = await ConnectedSocketPair.CreateAsync();
+                var stream = new ConcurrencyDetectingStream();
+                var transport = new TcpTransportConnection(socketPair.Server, stream);
+
+                // Step 1: batch A and flush. Write #1 starts and parks on the first gate (in flight).
+                transport.WriteUnflushed(a);
+                _ = transport.FlushAsync(); // fire-and-forget, exactly like the actor
+                (await Task.WhenAny(stream.FirstWriteStarted, Task.Delay(TimeSpan.FromSeconds(3))))
+                    .Should().BeSameAs(stream.FirstWriteStarted, "the first batch should start writing on the fast path");
+
+                // Step 2: batch B and flush while write #1 is in flight. B waits in the standby
+                // slot; on the buggy path this flush also spawns a detached backpressure
+                // continuation that will try to write B once write #1 finishes.
+                transport.WriteUnflushed(b);
+                _ = transport.FlushAsync(); // fire-and-forget
+
+                // Close the peer socket so the transport's inbound drain-on-close sees EOF and
+                // returns immediately (otherwise it polls the idle peer for the full drain budget,
+                // adding ~250ms per attempt).
+                socketPair.Client.Close();
+
+                // Step 3: graceful close. The drain also waits for write #1, then intends to write B.
+                var closeTask = transport.CloseAsync();
+
+                // Step 4: release write #1. Both the drain and (on the buggy path) the detached
+                // continuation wake up and race to write B, parking on the later gate.
+                stream.ReleaseFirstWrite();
+
+                // Let any racing second writer reach WriteAsync(B), then snapshot peak concurrency.
+                await AwaitConditionAsync(() => stream.LaterWritersParked >= 1, TimeSpan.FromSeconds(3));
+                var peakConcurrency = stream.MaxConcurrentWrites;
+
+                stream.ReleaseLaterWrites();
+                await closeTask.WaitAsync(TimeSpan.FromSeconds(5));
+                await transport.WriteCompleted.WaitAsync(TimeSpan.FromSeconds(5));
+
+                peakConcurrency.Should().Be(1,
+                    $"the double-buffer must never have two stream writes outstanding at once (attempt {attempt})");
+                stream.WrittenBytes.Should().Equal(expected,
+                    $"every buffered byte should reach the stream exactly once, in order (attempt {attempt})");
+
+                await transport.DisposeAsync();
+            }
+        }
+
+        /// <summary>
+        /// Concurrent-connections smoke test mirroring the benchmark workload: an echo server and N
+        /// concurrent clients each running an opening burst plus a sustained bidirectional echo
+        /// loop over a large number of round-trips. Complements the deterministic guard above by
+        /// exercising the real actor + transport stack end-to-end under concurrency; every
+        /// connection must complete its round-trips well inside the timeout.
+        /// </summary>
+        [Fact]
+        public async Task Many_concurrent_connections_with_sustained_writes_should_complete()
+        {
+            const int messageLength = 100;
+            const int clientsCount = 16;
+            const int messagesPerClient = 50_000; // round-trips driven per connection
+
+            var message = new byte[messageLength];
+
+            var bindProbe = CreateTestProbe("bind-probe");
+            var server = Sys.ActorOf(Props.Create(() => new EchoServer(messageLength)), "echo-server");
+            server.Tell(new SubscribeBound(bindProbe.Ref));
+            var bound = await bindProbe.ExpectMsgAsync<Tcp.Bound>(TimeSpan.FromSeconds(10));
+            var endpoint = (IPEndPoint)bound.LocalAddress;
+
+            var completions = new List<Task<bool>>(clientsCount);
+            for (var i = 0; i < clientsCount; i++)
+            {
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                completions.Add(tcs.Task);
+                Sys.ActorOf(Props.Create(() => new BurstEchoClient(endpoint, messagesPerClient, message, tcs)),
+                    $"burst-client-{i}");
+            }
+
+            var all = Task.WhenAll(completions);
+            var winner = await Task.WhenAny(all, Task.Delay(TimeSpan.FromSeconds(30)));
+
+            winner.Should().BeSameAs(all,
+                "all concurrent connections should complete their sustained writes without hanging");
+            (await all).Should().OnlyContain(ok => ok,
+                "no connection should observe a premature/error close before reaching its round-trip target");
+        }
+
+        private static async Task AwaitConditionAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (!condition())
+            {
+                if (DateTime.UtcNow > deadline)
+                    return;
+                await Task.Delay(10);
+            }
+        }
+
+        private static byte[] MakeBytes(char fill, int count)
+        {
+            var b = new byte[count];
+            for (var i = 0; i < count; i++)
+                b[i] = (byte)fill;
+            return b;
+        }
+
+        private static byte[] Concat(byte[] x, byte[] y)
+        {
+            var r = new byte[x.Length + y.Length];
+            Buffer.BlockCopy(x, 0, r, 0, x.Length);
+            Buffer.BlockCopy(y, 0, r, x.Length, y.Length);
+            return r;
+        }
+
+        /// <summary>
+        /// A <see cref="Stream"/> that (a) records the total bytes written in order, (b) tracks the
+        /// peak number of <see cref="WriteAsync(ReadOnlyMemory{byte},CancellationToken)"/> calls
+        /// outstanding at once (any value &gt; 1 means the double-buffer overlapped writes), and
+        /// (c) gates the FIRST write open until <see cref="ReleaseGate"/> so the test can hold a
+        /// write in flight on demand. Reads block forever (the spec drives only the write side).
+        /// </summary>
+        private sealed class ConcurrencyDetectingStream : Stream
+        {
+            private readonly object _sync = new();
+            private readonly List<byte> _written = new();
+
+            // Two gates. The FIRST write (batch A) parks on _firstGate; every LATER write parks on
+            // _laterGate. The test releases _firstGate to let write #1 finish, which wakes BOTH the
+            // drain and (on the buggy path) the detached backpressure continuation; they then race
+            // to write batch B and both park on _laterGate at once — so _maxConcurrent climbs above
+            // 1 and the bug is caught deterministically. The test then releases _laterGate.
+            private readonly TaskCompletionSource<bool> _firstGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource<bool> _laterGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource<bool> _firstWriteStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private int _concurrent;
+            private int _maxConcurrent;
+            private int _writeCount;
+            private int _laterWritersParked;
+
+            public int MaxConcurrentWrites
+            {
+                get { lock (_sync) { return _maxConcurrent; } }
+            }
+
+            public byte[] WrittenBytes
+            {
+                get { lock (_sync) { return _written.ToArray(); } }
+            }
+
+            public void ReleaseFirstWrite() => _firstGate.TrySetResult(true);
+            public void ReleaseLaterWrites() => _laterGate.TrySetResult(true);
+
+            public Task FirstWriteStarted => _firstWriteStarted.Task;
+
+            public int LaterWritersParked
+            {
+                get { lock (_sync) { return _laterWritersParked; } }
+            }
+
+            public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                int index;
+                lock (_sync)
+                {
+                    index = ++_writeCount;
+                    _concurrent++;
+                    if (_concurrent > _maxConcurrent)
+                        _maxConcurrent = _concurrent;
+                }
+
+                try
+                {
+                    if (index == 1)
+                    {
+                        _firstWriteStarted.TrySetResult(true);
+                        await _firstGate.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        lock (_sync) { _laterWritersParked++; }
+                        await _laterGate.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    lock (_sync)
+                    {
+                        for (var i = 0; i < buffer.Length; i++)
+                            _written.Add(buffer.Span[i]);
+                    }
+                }
+                finally
+                {
+                    lock (_sync)
+                    {
+                        _concurrent--;
+                    }
+                }
+            }
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                => WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+            public override void Write(byte[] buffer, int offset, int count)
+                => throw new NotSupportedException();
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+                return 0;
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override void Flush() { }
+            public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        }
+
+        private sealed class ConnectedSocketPair : IDisposable
+        {
+            private ConnectedSocketPair(Socket client, Socket server)
+            {
+                Client = client;
+                Server = server;
+            }
+
+            public Socket Client { get; }
+            public Socket Server { get; }
+
+            public static async Task<ConnectedSocketPair> CreateAsync()
+            {
+                using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                listener.Listen(1);
+
+                var endpoint = (IPEndPoint)listener.LocalEndPoint!;
+                var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                try
+                {
+                    var connectTask = client.ConnectAsync(endpoint);
+                    var server = await listener.AcceptAsync();
+                    await connectTask;
+                    return new ConnectedSocketPair(client, server);
+                }
+                catch
+                {
+                    client.Dispose();
+                    throw;
+                }
+            }
+
+            public void Dispose()
+            {
+                Client.Dispose();
+                Server.Dispose();
+            }
+        }
+
+        private sealed class SubscribeBound
+        {
+            public SubscribeBound(IActorRef subscriber) => Subscriber = subscriber;
+            public IActorRef Subscriber { get; }
+        }
+
+        private sealed class EchoServer : ReceiveActor
+        {
+            private IActorRef _subscriber = ActorRefs.Nobody;
+            private Tcp.Bound _bound;
+
+            public EchoServer(int messageSize)
+            {
+                Context.System.Tcp().Tell(new Tcp.Bind(Self, new IPEndPoint(IPAddress.Loopback, 0)));
+
+                Receive<SubscribeBound>(sub =>
+                {
+                    _subscriber = sub.Subscriber;
+                    if (_bound != null)
+                        _subscriber.Tell(_bound);
+                });
+                Receive<Tcp.Bound>(bound =>
+                {
+                    _bound = bound;
+                    if (!_subscriber.IsNobody())
+                        _subscriber.Tell(bound);
+                });
+                Receive<Tcp.Connected>(_ =>
+                {
+                    var connection = Context.ActorOf(Props.Create(() => new EchoConnection(Sender, messageSize)));
+                    Sender.Tell(new Tcp.Register(connection));
+                });
+            }
+        }
+
+        private sealed class EchoConnection : ReceiveActor
+        {
+            public EchoConnection(IActorRef connection, int messageSize)
+            {
+                var framer = new Framer(messageSize);
+                Receive<Tcp.Received>(received =>
+                {
+                    foreach (var m in framer.Deframe(received.Data))
+                        connection.Tell(Tcp.Write.Create(m));
+                });
+                Receive<Tcp.ConnectionClosed>(_ => Context.Stop(Self));
+            }
+        }
+
+        /// <summary>
+        /// Connects, registers, fires an opening burst, then echoes every framed message it
+        /// receives back to the server until it has driven <c>messagesToSend</c> round-trips, at
+        /// which point it reports completion and stops echoing. It deliberately does NOT issue a
+        /// <see cref="Tcp.Close"/>: this spec is scoped to write-side <em>liveness</em> under
+        /// concurrency (the connections are torn down with the actor system), keeping it
+        /// independent of the graceful-close path. Mirrors the benchmark's burst-of-20 + echo loop.
+        /// </summary>
+        private sealed class BurstEchoClient : ReceiveActor
+        {
+            private const int OpeningBurst = 20;
+
+            private readonly Framer _framer;
+            private readonly Tcp.WriteCommand _write;
+            private readonly TaskCompletionSource<bool> _done;
+            private readonly int _messagesToSend;
+            private IActorRef _connection = ActorRefs.Nobody;
+            private int _receivedCount;
+            private bool _finished;
+
+            public BurstEchoClient(IPEndPoint endpoint, int messagesToSend, byte[] message, TaskCompletionSource<bool> done)
+            {
+                _framer = new Framer(message.Length);
+                _messagesToSend = messagesToSend;
+                _done = done;
+                _write = Tcp.Write.Create(message.AsMemory());
+
+                Context.System.Tcp().Tell(new Tcp.Connect(endpoint, timeout: TimeSpan.FromSeconds(5)));
+
+                Receive<Tcp.Connected>(_ =>
+                {
+                    _connection = Sender;
+                    Sender.Tell(new Tcp.Register(Self));
+
+                    for (var i = 0; i < OpeningBurst; i++)
+                        _connection.Tell(_write);
+                });
+
+                Receive<Tcp.Received>(received =>
+                {
+                    if (_finished)
+                        return;
+
+                    foreach (var _ in _framer.Deframe(received.Data))
+                    {
+                        _receivedCount++;
+                        if (_receivedCount >= _messagesToSend)
+                        {
+                            _finished = true;
+                            _done.TrySetResult(true);
+                            return;
+                        }
+
+                        _connection.Tell(_write);
+                    }
+                });
+
+                // Any close or write failure before the target means the workload didn't complete.
+                Receive<Tcp.ConnectionClosed>(_ => _done.TrySetResult(_finished));
+                Receive<Tcp.CommandFailed>(_ => _done.TrySetResult(_finished));
+            }
+        }
+
+        private sealed class Framer
+        {
+            private readonly int _messageSize;
+            private ReadOnlySequence<byte> _partialRead = ReadOnlySequence<byte>.Empty;
+
+            public Framer(int messageSize) => _messageSize = messageSize;
+
+            public IEnumerable<ReadOnlySequence<byte>> Deframe(ReadOnlySequence<byte> data)
+            {
+                if (_partialRead.Length > 0)
+                {
+                    var partialLen = (int)_partialRead.Length;
+                    var combined = new byte[partialLen + (int)data.Length];
+                    _partialRead.CopyTo(combined.AsSpan(0, partialLen));
+                    data.CopyTo(combined.AsSpan(partialLen));
+                    data = new ReadOnlySequence<byte>(combined);
+                    _partialRead = ReadOnlySequence<byte>.Empty;
+                }
+
+                var msgs = new List<ReadOnlySequence<byte>>();
+                var offset = 0;
+                while (offset + _messageSize <= data.Length)
+                {
+                    msgs.Add(data.Slice(offset, _messageSize));
+                    offset += _messageSize;
+                }
+
+                if (offset < data.Length)
+                    _partialRead = data.Slice(offset, (int)data.Length - offset);
+
+                return msgs;
+            }
+        }
+    }
+}

--- a/src/core/Akka.Tests/IO/TcpGracefulCloseRaceSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpGracefulCloseRaceSpec.cs
@@ -1,0 +1,309 @@
+//-----------------------------------------------------------------------
+// <copyright file="TcpGracefulCloseRaceSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.IO;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Tests.IO
+{
+    /// <summary>
+    /// Regression coverage for the read-side close race in <see cref="TcpTransportConnection"/>.
+    /// <para>
+    /// The inbound side is consumer-driven (no read pump): the owning <see cref="TcpConnection"/>
+    /// actor keeps a <see cref="System.IO.Pipelines.PipeReader.ReadAsync"/> in flight on the
+    /// transport's <c>StreamPipeReader</c>. On a graceful <see cref="TcpTransportConnection.CloseAsync"/>
+    /// the transport used to call <c>Complete()</c> on that reader immediately after cancelling its
+    /// CTS — while the consumer's read could still be parked inside the inner stream read. A
+    /// <c>StreamPipeReader</c> is NOT safe to <c>Complete()</c> with a read in flight:
+    /// <c>Complete()</c> resets the <c>BufferSegment</c> the resuming read commits bytes into, so
+    /// the read does <c>segment.End += bytesRead</c> against a now-zero-length segment and throws
+    /// <see cref="ArgumentOutOfRangeException"/> out of <c>BufferSegment.set_End</c>. That surfaces
+    /// to the actor as an I/O error and to the peer as a spurious <c>ErrorClosed</c> on an otherwise
+    /// clean close.
+    /// </para>
+    /// <para>
+    /// The single-close coverage in the other specs never lands inside that window, so it misses
+    /// the bug. The two tests below pin it:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><b>Deterministic guard</b> — drives the exact interleaving (read parked in the inner
+    /// stream, then <see cref="TcpTransportConnection.CloseAsync"/>, then the read resumes with
+    /// bytes) with a gated fake stream, and asserts the in-flight read never throws
+    /// <see cref="ArgumentOutOfRangeException"/> and the close completes cleanly.</item>
+    /// <item><b>End-to-end loop</b> — many real connect / exchange / <see cref="Tcp.Close"/> cycles
+    /// through the full actor + transport stack, asserting every close is clean (never
+    /// <see cref="Tcp.ErrorClosed"/>).</item>
+    /// </list>
+    /// </summary>
+    public class TcpGracefulCloseRaceSpec : AkkaSpec
+    {
+        public TcpGracefulCloseRaceSpec(ITestOutputHelper output)
+            : base("akka.loglevel = INFO\nakka.log-dead-letters = off", output: output)
+        {
+        }
+
+        /// <summary>
+        /// Deterministic guard: a consumer read parked inside the inner stream read, then a graceful
+        /// <see cref="TcpTransportConnection.CloseAsync"/>, then the read resumes with bytes. On the
+        /// buggy code the concurrent <c>Complete()</c> resets the segment the read commits into and
+        /// the resuming read throws <see cref="ArgumentOutOfRangeException"/> from
+        /// <c>BufferSegment.set_End</c>; with the fix the close quiesces the in-flight read before
+        /// completing the reader, so the read settles cleanly (cancelled) and never throws.
+        /// </summary>
+        [Fact]
+        public async Task CloseAsync_should_not_corrupt_an_in_flight_read_on_the_StreamPipeReader()
+        {
+            // Repeat: even though the gated stream makes the ordering deterministic per attempt, we
+            // loop so any residual scheduling variance is covered. The buggy path throws on the very
+            // first attempt; the fix upholds the invariant on every one.
+            const int attempts = 50;
+
+            for (var attempt = 0; attempt < attempts; attempt++)
+            {
+                using var socketPair = await ConnectedSocketPair.CreateAsync();
+                var stream = new GatedReadStream();
+                var transport = new TcpTransportConnection(socketPair.Server, stream);
+
+                // The consumer (acting as the actor) issues a ReadAsync. It allocates a read-tail
+                // segment and parks inside GatedReadStream.ReadAsync — exactly the window the close
+                // path must serialize against.
+                ArgumentOutOfRangeException? readFault = null;
+                var readTask = Task.Run(async () =>
+                {
+                    try
+                    {
+                        var result = await transport.Input.ReadAsync(CancellationToken.None);
+                        transport.Input.AdvanceTo(result.Buffer.End);
+                    }
+                    catch (ArgumentOutOfRangeException ex)
+                    {
+                        // The exact corruption: segment.End set against a reset (zero-length)
+                        // segment. This is what the bug produces and what the fix must prevent.
+                        readFault = ex;
+                    }
+                    catch (Exception)
+                    {
+                        // Any other outcome (cancelled / completed / disposed) is a clean settle.
+                    }
+                });
+
+                // Wait until the read is actually parked inside the inner stream read (tail segment
+                // allocated, sitting in ReadAsync) — that is the precondition for the race.
+                (await Task.WhenAny(stream.ReadStarted, Task.Delay(TimeSpan.FromSeconds(3))))
+                    .Should().BeSameAs(stream.ReadStarted, $"the consumer read should park in the stream (attempt {attempt})");
+
+                // Close the peer so the transport's bounded inbound drain sees EOF immediately
+                // (otherwise it polls the idle peer for the whole drain budget).
+                socketPair.Client.Close();
+
+                // Graceful close. On the buggy path this completes the StreamPipeReader while the
+                // read above is still parked — corrupting the segment it is about to commit into.
+                var closeTask = transport.CloseAsync();
+
+                // Release the parked read so it resumes WITH bytes. On the buggy path it now does
+                // segment.End += bytes against the reset segment and throws ArgumentOutOfRangeException.
+                stream.ReleaseRead(bytes: 64);
+
+                await readTask.WaitAsync(TimeSpan.FromSeconds(5));
+                await closeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+                readFault.Should().BeNull(
+                    $"completing the StreamPipeReader must never race an in-flight read (attempt {attempt}): {readFault?.Message}");
+
+                await transport.DisposeAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end guard: many real graceful-close cycles through the full actor + transport
+        /// stack. Each cycle exchanges a little data both ways (so both sides have a live inbound
+        /// read), then the client issues <see cref="Tcp.Close"/>. Every close must be clean —
+        /// <see cref="Tcp.Closed"/> on the initiator and <see cref="Tcp.PeerClosed"/> on the peer —
+        /// and never <see cref="Tcp.ErrorClosed"/> (which is how the corruption surfaces).
+        /// </summary>
+        [Fact]
+        public async Task Repeated_graceful_close_should_never_ErrorClose_the_peer()
+        {
+            var bindHandler = CreateTestProbe("bind-handler");
+            var bindCommander = CreateTestProbe("bind-commander");
+            bindCommander.Send(Sys.Tcp(),
+                new Tcp.Bind(bindHandler.Ref, new IPEndPoint(IPAddress.Loopback, 0)));
+            IPEndPoint endpoint = null!;
+            await bindCommander.ExpectMsgAsync<Tcp.Bound>(b => endpoint = (IPEndPoint)b.LocalAddress);
+
+            const int cycles = 100;
+            var payload = new byte[] { 1, 2, 3, 4 };
+
+            for (var cycle = 0; cycle < cycles; cycle++)
+                await RunOneCycleAsync(endpoint, bindHandler, payload, cycle);
+        }
+
+        private async Task RunOneCycleAsync(
+            IPEndPoint endpoint, TestProbe bindHandler, byte[] payload, int cycle)
+        {
+            var connectCommander = CreateTestProbe($"connect-{cycle}");
+            connectCommander.Send(Sys.Tcp(), new Tcp.Connect(endpoint));
+            await connectCommander.ExpectMsgAsync<Tcp.Connected>();
+            var clientConnection = connectCommander.Sender;
+
+            var clientHandler = CreateTestProbe($"client-handler-{cycle}");
+            clientConnection.Tell(new Tcp.Register(clientHandler.Ref));
+
+            await bindHandler.ExpectMsgAsync<Tcp.Connected>();
+            var serverConnection = bindHandler.Sender;
+            var serverHandler = CreateTestProbe($"server-handler-{cycle}");
+            serverConnection.Tell(new Tcp.Register(serverHandler.Ref));
+
+            // Exchange a little data each way so both sides have a live inbound read going.
+            clientHandler.Send(clientConnection, Tcp.Write.Create(payload.AsMemory()));
+            await serverHandler.ExpectMsgAsync<Tcp.Received>(
+                r => r.Data.Length == payload.Length, hint: $"server recv at cycle {cycle}");
+
+            serverHandler.Send(serverConnection, Tcp.Write.Create(payload.AsMemory()));
+            await clientHandler.ExpectMsgAsync<Tcp.Received>(
+                r => r.Data.Length == payload.Length, hint: $"client recv at cycle {cycle}");
+
+            // Graceful close from the client.
+            clientHandler.Send(clientConnection, Tcp.Close.Instance);
+
+            var clientClose = await FishForCloseAsync(clientHandler, cycle, "client");
+            clientClose.Should().BeOfType<Tcp.Closed>(
+                $"client close at cycle {cycle} must be a clean Closed, was: {Describe(clientClose)}");
+
+            var serverClose = await FishForCloseAsync(serverHandler, cycle, "server");
+            serverClose.Should().NotBeOfType<Tcp.ErrorClosed>(
+                $"server close at cycle {cycle} must be clean, was: {Describe(serverClose)}");
+        }
+
+        private static async Task<Tcp.ConnectionClosed> FishForCloseAsync(
+            TestProbe handler, int cycle, string side)
+        {
+            var msg = await handler.FishForMessageAsync(
+                m => m is Tcp.ConnectionClosed,
+                TimeSpan.FromSeconds(10),
+                hint: $"{side} close result at cycle {cycle}");
+            return (Tcp.ConnectionClosed)msg;
+        }
+
+        private static string Describe(Tcp.ConnectionClosed closed)
+            => closed is Tcp.ErrorClosed err
+                ? $"ErrorClosed(\"{err.Cause}\")"
+                : closed.GetType().Name;
+
+        /// <summary>
+        /// A <see cref="Stream"/> whose <see cref="ReadAsync(Memory{byte},CancellationToken)"/>
+        /// parks on a gate (signalling <see cref="ReadStarted"/> once the read is parked) and, on
+        /// <see cref="ReleaseRead"/>, resumes returning a positive byte count. Parking the read lets
+        /// the test put the transport's <c>StreamPipeReader</c> into the exact state the close path
+        /// must serialize against; releasing it with bytes triggers the
+        /// <c>segment.End += bytes</c> commit that throws on the buggy path. Writes are accepted
+        /// (the close path flushes nothing meaningful here).
+        /// </summary>
+        private sealed class GatedReadStream : Stream
+        {
+            private readonly TaskCompletionSource<bool> _readStarted =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource<int> _releaseRead =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private int _readCount;
+
+            public Task ReadStarted => _readStarted.Task;
+
+            /// <summary>Releases the parked read so it resumes returning <paramref name="bytes"/>.</summary>
+            public void ReleaseRead(int bytes) => _releaseRead.TrySetResult(bytes);
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                // Only the FIRST read parks on the gate; later reads (e.g. the close path's drain)
+                // just block on cancellation so they don't interfere with the staged race.
+                if (Interlocked.Increment(ref _readCount) == 1)
+                {
+                    _readStarted.TrySetResult(true);
+                    var bytes = await _releaseRead.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    return Math.Min(bytes, buffer.Length);
+                }
+
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+                return 0;
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+                => ValueTask.CompletedTask;
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+
+            public override void Write(byte[] buffer, int offset, int count) { }
+
+            public override void Flush() { }
+            public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        }
+
+        private sealed class ConnectedSocketPair : IDisposable
+        {
+            private ConnectedSocketPair(Socket client, Socket server)
+            {
+                Client = client;
+                Server = server;
+            }
+
+            public Socket Client { get; }
+            public Socket Server { get; }
+
+            public static async Task<ConnectedSocketPair> CreateAsync()
+            {
+                using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                listener.Listen(1);
+
+                var endpoint = (IPEndPoint)listener.LocalEndPoint!;
+                var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                try
+                {
+                    var connectTask = client.ConnectAsync(endpoint);
+                    var server = await listener.AcceptAsync();
+                    await connectTask;
+                    return new ConnectedSocketPair(client, server);
+                }
+                catch
+                {
+                    client.Dispose();
+                    throw;
+                }
+            }
+
+            public void Dispose()
+            {
+                Client.Dispose();
+                Server.Dispose();
+            }
+        }
+    }
+}

--- a/src/core/Akka/IO/TcpConnection.cs
+++ b/src/core/Akka/IO/TcpConnection.cs
@@ -681,16 +681,30 @@ namespace Akka.IO
                     // No read pump: when WE deliberately close/abort, the actor disposes the
                     // transport, which faults the in-flight PipeReader.ReadAsync. The faults
                     // that OUR OWN teardown produces — ObjectDisposedException (we disposed the
-                    // stream/socket), OperationCanceledException (our CTS), or
+                    // stream/socket), OperationCanceledException (our CTS),
                     // InvalidOperationException (we completed the PipeReader under an in-flight
-                    // read) — are an expected, clean termination, so surface them as a
-                    // cancellation rather than an I/O failure.
+                    // read), or ArgumentOutOfRangeException (a teardown recycled a pooled segment a
+                    // read was mid-commit on) — are an expected, clean termination, so surface them
+                    // as a cancellation rather than an I/O failure.
                     //
                     // A genuine transport error (SocketException / IOException wrapping a
                     // socket reset) is NOT swallowed even while closing: it falls through to
                     // the IoTaskFailed branch below so a real reset/abort still surfaces as
                     // ErrorClosed. This matters for the half-close + error case where the peer
                     // legitimately errors after we've started shutting down.
+                    self.Tell(PipeReadCanceled.Instance);
+                }
+                catch (Exception) when (_closingGracefully && ct.IsCancellationRequested)
+                {
+                    // Defense-in-depth: once we are closing gracefully AND our CTS has been
+                    // cancelled (TryCancelCts runs on every close/abort path), the connection is
+                    // already being torn down deterministically by us. ANY read fault here is a
+                    // teardown artefact, not a peer error — a peer reset that mattered would have
+                    // surfaced before we cancelled. Treat it as a clean cancellation so a
+                    // teardown-induced read fault becomes Closed, never a spurious ErrorClosed that
+                    // the peer (which only handles Tcp.Closed) would silently drop — hanging the
+                    // coordinating Ask forever. ct is _cts.Token, so this is exactly the
+                    // "_closingGracefully && _cts.IsCancellationRequested" condition.
                     self.Tell(PipeReadCanceled.Instance);
                 }
                 catch (Exception ex)
@@ -707,10 +721,13 @@ namespace Akka.IO
         ///
         /// Our teardown completes the <see cref="PipeReader"/> and disposes the underlying
         /// stream/socket; that surfaces as <see cref="ObjectDisposedException"/>,
-        /// <see cref="OperationCanceledException"/>, or <see cref="InvalidOperationException"/>
-        /// ("reading is not allowed after the reader was completed"). A real connection reset
-        /// surfaces as a <see cref="SocketException"/> (possibly wrapped in an
-        /// <see cref="IOException"/>) and must NOT be treated as a clean close.
+        /// <see cref="OperationCanceledException"/>, <see cref="InvalidOperationException"/>
+        /// ("reading is not allowed after the reader was completed"), or — when a teardown
+        /// recycles a pooled <c>BufferSegment</c> a read is mid-commit on —
+        /// <see cref="ArgumentOutOfRangeException"/> out of <c>BufferSegment.set_End</c> /
+        /// <c>BuffersExtensions.CopyTo</c>. A real connection reset surfaces as a
+        /// <see cref="SocketException"/> (possibly wrapped in an <see cref="IOException"/>) and
+        /// must NOT be treated as a clean close.
         /// </summary>
         private static bool IsOwnShutdownFault(Exception ex)
         {
@@ -719,6 +736,15 @@ namespace Akka.IO
                 case ObjectDisposedException:
                 case OperationCanceledException:
                 case InvalidOperationException:
+                    return true;
+                case ArgumentOutOfRangeException:
+                    // Defense-in-depth: completing/recycling a StreamPipeReader's pooled segment
+                    // while an in-flight read is mid-commit throws ArgumentOutOfRangeException
+                    // (Parameter 'start' / 'length') from BufferSegment.set_End or
+                    // BuffersExtensions.CopyTo. The ReadGate now copies bytes out inside the gate so
+                    // this should no longer be reachable, but if a teardown ever re-opens that
+                    // window it is OUR OWN shutdown corrupting the read — not a peer error — so it
+                    // must become a clean PipeReadCanceled → Closed, never an ErrorClosed.
                     return true;
                 case IOException io when io.InnerException is SocketException:
                     // IOException wrapping a socket error is a genuine transport failure
@@ -814,27 +840,20 @@ namespace Akka.IO
             while (true)
             {
                 var result = await reader.ReadAsync(ct).ConfigureAwait(false);
-                var buffer = result.Buffer;
 
-                // We must copy out of the pipe's pooled segments before AdvanceTo because
-                // Tell is non-blocking — the handler may not have consumed the data by the
-                // time the segments are returned to the pool. Zero-copy reads require an
-                // explicit ack protocol with the handler that's out of scope here.
-                // The result is wrapped in ReadOnlySequence<byte> (single-segment in practice)
-                // so downstream Streams stages can chain sequences without further copies.
-                ReadOnlySequence<byte> data;
-                if (buffer.Length > 0)
-                {
-                    var array = new byte[checked((int)buffer.Length)];
-                    buffer.CopyTo(array);
-                    data = new ReadOnlySequence<byte>(array);
-                }
-                else
-                {
-                    data = ReadOnlySequence<byte>.Empty;
-                }
-
-                reader.AdvanceTo(buffer.End);
+                // The transport's ReadGate has already copied the bytes out of the underlying
+                // StreamPipeReader's pooled segments into a fresh, segment-independent array and
+                // advanced the underlying reader past them — all while the read was still tracked
+                // in-flight, so a concurrent Complete() (close/abort) can never recycle those
+                // segments under us. That means the buffer we get here is safe to hand to the
+                // (non-blocking) handler without a second copy: it is NOT backed by recyclable pool
+                // memory. (Before the gate copied internally, copying here OUTSIDE the gate is what
+                // produced the concurrent-close ArgumentOutOfRangeException → spurious ErrorClosed.)
+                //
+                // AdvanceTo is a no-op on the gate (the underlying reader was already advanced
+                // inside it); we call it to honour the PipeReader read/advance contract.
+                var data = result.Buffer;
+                reader.AdvanceTo(data.End);
 
                 if (data.Length > 0 || result.IsCompleted || result.IsCanceled)
                     return new PipeReadCompleted(data, result.IsCompleted, result.IsCanceled);

--- a/src/core/Akka/IO/TcpConnection.cs
+++ b/src/core/Akka/IO/TcpConnection.cs
@@ -236,7 +236,7 @@ namespace Akka.IO
 
         // We've initiated a graceful close (HandleClose has run). Used to fast-fail
         // any further Tcp.Write commands with DroppingWriteBecauseClosingException.
-        private bool _closingGracefully;
+        private volatile bool _closingGracefully;
 
         // The pipe-reader pump task observed completion (EOF or error). Read path
         // gates on this together with _outputShutdown to know when TryFinishClose
@@ -548,9 +548,15 @@ namespace Akka.IO
             });
             Receive<IoTaskFailed>(msg =>
             {
+                // A genuine inbound I/O failure (e.g. the peer reset/aborted) arrived while we
+                // were gracefully closing. Our-own-shutdown faults were already reclassified as
+                // PipeReadCanceled before reaching here, so this is a real error and must win
+                // over the intended graceful close event: report ErrorClosed, not the pending
+                // Closed/ConfirmedClosed. This is what surfaces a remote abort during a
+                // half-close as an error rather than a clean confirmed-close.
                 if (_traceLogging)
                     Log.Debug("I/O task failed during close: {0}", msg.Cause.Message);
-                DoCloseConnection(closeSender, closeEvent);
+                DoCloseConnection(closeSender, new ErrorClosed(msg.Cause.Message));
             });
             SuspendResumeHandlers();
             Receive<HandlerDied>(_ =>
@@ -670,10 +676,61 @@ namespace Akka.IO
                 {
                     self.Tell(PipeReadCanceled.Instance);
                 }
+                catch (Exception ex) when (_closingGracefully && IsOwnShutdownFault(ex))
+                {
+                    // No read pump: when WE deliberately close/abort, the actor disposes the
+                    // transport, which faults the in-flight PipeReader.ReadAsync. The faults
+                    // that OUR OWN teardown produces — ObjectDisposedException (we disposed the
+                    // stream/socket), OperationCanceledException (our CTS), or
+                    // InvalidOperationException (we completed the PipeReader under an in-flight
+                    // read) — are an expected, clean termination, so surface them as a
+                    // cancellation rather than an I/O failure.
+                    //
+                    // A genuine transport error (SocketException / IOException wrapping a
+                    // socket reset) is NOT swallowed even while closing: it falls through to
+                    // the IoTaskFailed branch below so a real reset/abort still surfaces as
+                    // ErrorClosed. This matters for the half-close + error case where the peer
+                    // legitimately errors after we've started shutting down.
+                    self.Tell(PipeReadCanceled.Instance);
+                }
                 catch (Exception ex)
                 {
                     self.Tell(new IoTaskFailed(ex));
                 }
+            }
+        }
+
+        /// <summary>
+        /// Classifies whether a fault raised by an in-flight <see cref="PipeReader.ReadAsync"/>
+        /// was caused by OUR OWN deliberate teardown (and is therefore a clean termination)
+        /// rather than a genuine transport error from the peer.
+        ///
+        /// Our teardown completes the <see cref="PipeReader"/> and disposes the underlying
+        /// stream/socket; that surfaces as <see cref="ObjectDisposedException"/>,
+        /// <see cref="OperationCanceledException"/>, or <see cref="InvalidOperationException"/>
+        /// ("reading is not allowed after the reader was completed"). A real connection reset
+        /// surfaces as a <see cref="SocketException"/> (possibly wrapped in an
+        /// <see cref="IOException"/>) and must NOT be treated as a clean close.
+        /// </summary>
+        private static bool IsOwnShutdownFault(Exception ex)
+        {
+            switch (ex)
+            {
+                case ObjectDisposedException:
+                case OperationCanceledException:
+                case InvalidOperationException:
+                    return true;
+                case IOException io when io.InnerException is SocketException:
+                    // IOException wrapping a socket error is a genuine transport failure
+                    // (e.g. connection reset/aborted) — not our own shutdown.
+                    return false;
+                case IOException io when io.InnerException is ObjectDisposedException:
+                    // IOException wrapping a dispose is our own teardown racing the read.
+                    return true;
+                case SocketException:
+                    return false;
+                default:
+                    return false;
             }
         }
 

--- a/src/core/Akka/IO/TcpTransportConnection.cs
+++ b/src/core/Akka/IO/TcpTransportConnection.cs
@@ -701,7 +701,23 @@ namespace Akka.IO
 
                 try
                 {
-                    return await read.ConfigureAwait(false);
+                    // CRITICAL: do the copy-out + AdvanceTo on the underlying StreamPipeReader
+                    // HERE, while this read is still tracked as in-flight (_inflightRead == read).
+                    // The StreamPipeReader's BufferSegments are pooled and get recycled the moment
+                    // Complete() runs. If we returned the raw ReadResult and let the consumer copy
+                    // it out and AdvanceTo *outside* the gate, a teardown that observed
+                    // _inflightRead == null (because this read already returned) could call
+                    // _inner.Complete() and recycle those segments while the consumer is mid-CopyTo
+                    // — throwing ArgumentOutOfRangeException out of BuffersExtensions.CopyTo /
+                    // BufferSegment.set_End and surfacing to the peer as a spurious ErrorClosed.
+                    //
+                    // By snapshotting the bytes into a fresh, segment-independent array and calling
+                    // _inner.AdvanceTo before we clear _inflightRead, the consumer never touches the
+                    // recyclable segments and Complete() can never race them. The single copy here
+                    // replaces the one the consumer used to do, so per-message allocation is
+                    // unchanged.
+                    var result = await read.ConfigureAwait(false);
+                    return SnapshotAndAdvance(result);
                 }
                 finally
                 {
@@ -729,6 +745,36 @@ namespace Akka.IO
                 }
             }
 
+            /// <summary>
+            /// Copies the just-read bytes out of the underlying <c>StreamPipeReader</c>'s pooled
+            /// segments into a fresh, segment-independent array and advances the underlying reader
+            /// past them — all while the read is still tracked in-flight so a concurrent
+            /// <see cref="Complete"/> cannot recycle the segments out from under the copy. The
+            /// returned <see cref="ReadResult"/> is backed by the copied array, so the consumer
+            /// never touches the recyclable segments. Empty reads (EOF / cancellation) return a
+            /// default-buffer result without allocating.
+            /// </summary>
+            private ReadResult SnapshotAndAdvance(ReadResult result)
+            {
+                var buffer = result.Buffer;
+                if (buffer.Length == 0)
+                {
+                    // Nothing to copy. Still advance the underlying reader so it does not see the
+                    // same (empty) segment again, then surface the completion/cancel flags.
+                    _inner.AdvanceTo(buffer.Start, buffer.End);
+                    return new ReadResult(ReadOnlySequence<byte>.Empty, result.IsCanceled, result.IsCompleted);
+                }
+
+                var array = new byte[checked((int)buffer.Length)];
+                buffer.CopyTo(array);
+
+                // Consume everything we copied. We are still inside the gate (this read is still
+                // _inflightRead), so this AdvanceTo cannot race a Complete() on _inner.
+                _inner.AdvanceTo(buffer.End);
+
+                return new ReadResult(new ReadOnlySequence<byte>(array), result.IsCanceled, result.IsCompleted);
+            }
+
             public override bool TryRead(out ReadResult result)
             {
                 lock (_sync)
@@ -738,15 +784,32 @@ namespace Akka.IO
                         result = new ReadResult(default, isCanceled: true, isCompleted: true);
                         return true;
                     }
-                }
 
-                return _inner.TryRead(out result);
+                    if (!_inner.TryRead(out var inner))
+                    {
+                        result = default;
+                        return false;
+                    }
+
+                    // Snapshot + advance under _sync (same lock Complete() takes) so the segments
+                    // can't be recycled out from under the copy. Mirrors SnapshotAndAdvance so a
+                    // TryRead consumer also gets a segment-independent ReadResult, even though no
+                    // current caller uses TryRead on this reader.
+                    result = SnapshotAndAdvance(inner);
+                    return true;
+                }
             }
 
-            public override void AdvanceTo(SequencePosition consumed) => _inner.AdvanceTo(consumed);
+            // No-ops: ReadAsync already copied the bytes out of the underlying reader's pooled
+            // segments and advanced _inner past them (see SnapshotAndAdvance), so the ReadResult
+            // the consumer holds is segment-independent. The consumer's AdvanceTo therefore refers
+            // to the synthetic snapshot buffer, not _inner — forwarding it would double-advance the
+            // underlying StreamPipeReader. Keeping these as no-ops preserves the PipeReader
+            // contract for the consumer while ensuring _inner is advanced exactly once, inside the
+            // gate, before _inflightRead is cleared.
+            public override void AdvanceTo(SequencePosition consumed) { }
 
-            public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
-                => _inner.AdvanceTo(consumed, examined);
+            public override void AdvanceTo(SequencePosition consumed, SequencePosition examined) { }
 
             public override void CancelPendingRead()
             {

--- a/src/core/Akka/IO/TcpTransportConnection.cs
+++ b/src/core/Akka/IO/TcpTransportConnection.cs
@@ -19,19 +19,34 @@ namespace Akka.IO
 {
     /// <summary>
     /// Plaintext TCP implementation of <see cref="ITransportConnection"/>.
-    /// Owns two pipes (input + output) and two pump loops that bridge them to a NetworkStream.
+    /// Owns an output pipe + write pump that bridge to a NetworkStream, and exposes a
+    /// <see cref="PipeReader"/> for the inbound side that the consuming actor drives directly.
     /// </summary>
     public sealed class TcpTransportConnection : ITransportConnection
     {
+        // Segment size for the inbound StreamPipeReader. Large enough that one ReadAsync
+        // typically pulls a full kernel receive buffer in a single call.
+        private const int ReadBufferSize = 64 * 1024;
+
+        // Bounds for the drain-on-close. Closing a socket that still has unread inbound
+        // data in the kernel receive buffer makes the OS emit RST instead of FIN, so the
+        // peer would observe a "connection reset" error instead of a clean close. Before we
+        // close we therefore drain pending inbound bytes (until the peer's FIN, or until we
+        // hit these caps) so the OS can complete a graceful FIN/ACK exchange. The caps keep
+        // a pathological peer that keeps shoving data at us from blocking close forever.
+        private const int DrainMaxBytes = 1024 * 1024;
+        private static readonly TimeSpan DrainTimeout = TimeSpan.FromMilliseconds(250);
+
         private readonly Socket _socket;
         private readonly Stream _stream;
-        private readonly Pipe _inputPipe;
+        private readonly PipeReader _inputReader;
         private readonly Pipe _outputPipe;
         private readonly CancellationTokenSource _cts = new();
 
         /// <summary>
         /// Creates a transport connection from an already-connected socket.
-        /// Starts the read and write pump loops immediately.
+        /// Starts the write pump loop immediately; inbound reads are driven on demand
+        /// by the consumer via <see cref="Input"/>.
         /// </summary>
         public TcpTransportConnection(Socket socket, PipeOptions? inputPipeOptions = null,
             PipeOptions? outputPipeOptions = null)
@@ -39,10 +54,16 @@ namespace Akka.IO
             _socket = socket;
             _stream = new NetworkStream(socket, ownsSocket: false);
 
-            _inputPipe = new Pipe(inputPipeOptions ?? PipeOptions.Default);
+            // Inbound: no background read pump. The consumer (TcpConnection actor) drives
+            // PipeReader.ReadAsync directly, so a socket read runs on the consumer's own
+            // continuation instead of being flushed across a Pipe to a second thread — this
+            // removes the pump→Pipe→consumer cross-thread hand-off (one fewer thread-pool
+            // dispatch per chunk). inputPipeOptions (readerScheduler etc.) is intentionally
+            // unused now that there is no Pipe on the read side.
+            _inputReader = PipeReader.Create(_stream, new StreamPipeReaderOptions(bufferSize: ReadBufferSize, leaveOpen: true));
             _outputPipe = new Pipe(outputPipeOptions ?? PipeOptions.Default);
 
-            ReadCompleted = RunReadPumpAsync(_cts.Token);
+            ReadCompleted = Task.CompletedTask;
             WriteCompleted = RunWritePumpAsync(_cts.Token);
         }
 
@@ -55,14 +76,16 @@ namespace Akka.IO
             _socket = socket;
             _stream = stream;
 
-            _inputPipe = new Pipe(inputPipeOptions ?? PipeOptions.Default);
+            // See the socket-only constructor: the inbound side is a consumer-driven
+            // PipeReader, not a background pump + Pipe.
+            _inputReader = PipeReader.Create(_stream, new StreamPipeReaderOptions(bufferSize: ReadBufferSize, leaveOpen: true));
             _outputPipe = new Pipe(outputPipeOptions ?? PipeOptions.Default);
 
-            ReadCompleted = RunReadPumpAsync(_cts.Token);
+            ReadCompleted = Task.CompletedTask;
             WriteCompleted = RunWritePumpAsync(_cts.Token);
         }
 
-        public PipeReader Input => _inputPipe.Reader;
+        public PipeReader Input => _inputReader;
 
         /// <inheritdoc/>
         public Task ReadCompleted { get; }
@@ -71,13 +94,13 @@ namespace Akka.IO
         public Task WriteCompleted { get; }
 
         /// <inheritdoc/>
-        public bool HasReadError => Volatile.Read(ref _hasReadError);
+        // No background read pump: read errors surface synchronously from the consumer's
+        // PipeReader.ReadAsync (the TcpConnection actor catches them and reports IoTaskFailed),
+        // so there is no out-of-band error to latch here.
+        public bool HasReadError => false;
 
         /// <inheritdoc/>
-        public Exception? ReadError => Volatile.Read(ref _readError);
-
-        private bool _hasReadError;
-        private Exception? _readError;
+        public Exception? ReadError => null;
 
         internal void WriteUnflushed(ReadOnlyMemory<byte> data)
         {
@@ -112,6 +135,12 @@ namespace Akka.IO
 
         public async Task ShutdownAsync()
         {
+            // Tcp.ConfirmedClose: this is a HALF close. Flush our pending writes, then send
+            // FIN (Shutdown(Send)) but leave the read side open. The consuming actor keeps
+            // driving the inbound PipeReader until it observes the peer's FIN (EOF), at which
+            // point it finalizes the close. We must NOT drain here — that inbound data still
+            // belongs to the consumer.
+
             // Complete the output pipe — write pump will drain and exit
             await _outputPipe.Writer.CompleteAsync().ConfigureAwait(false);
 
@@ -125,27 +154,104 @@ namespace Akka.IO
                 _socket.Shutdown(SocketShutdown.Send);
             }
             catch (SocketException) { } // slopwatch-ignore: SW003 socket may already be closed by peer or abort
+            catch (ObjectDisposedException) { } // slopwatch-ignore: SW003 socket may already be disposed by an abort
         }
 
         public async Task CloseAsync()
         {
+            // Tcp.Close: full, graceful close. Flush pending writes, send our FIN, drain any
+            // still-buffered inbound bytes so the OS sends FIN (not RST) on the final close,
+            // then tear everything down.
+
             // Complete the output pipe — write pump will drain and exit
             await _outputPipe.Writer.CompleteAsync().ConfigureAwait(false);
 
             // Wait for write pump to finish flushing
             await WriteCompleted.ConfigureAwait(false);
 
-            // Cancel to unblock the read pump (which may be blocked on stream.ReadAsync)
-            _cts.Cancel();
+            // Send our FIN now (half-close the send side). Doing this before the drain lets
+            // the peer observe our orderly shutdown and reciprocate while we read out whatever
+            // it already sent us. SocketException/ObjectDisposedException can occur if the peer
+            // already reset us or an abort raced in — both are fine, we're closing anyway.
+            try
+            {
+                _socket.Shutdown(SocketShutdown.Send);
+            }
+            catch (SocketException) { } // slopwatch-ignore: SW003 socket may already be closed by peer or abort
+            catch (ObjectDisposedException) { } // slopwatch-ignore: SW003 socket may already be disposed by an abort
 
-            // Wait for read pump to exit — it may throw OperationCanceledException (from CTS cancel)
-            // or IOException/SocketException (from stream close). Both are expected during shutdown.
+            // Cancel to unblock the write pump; the inbound reader is consumer-driven,
+            // so completing it releases any pooled buffers and frees the underlying stream
+            // for the bounded socket-level drain below.
+            _cts.Cancel();
+            try { _inputReader.Complete(); } catch (Exception) { } // slopwatch-ignore: SW003 reader may have an in-flight read during teardown
+
+            // Wait for read completion — no background pump, so this is already complete.
             try { await ReadCompleted.ConfigureAwait(false); }
             catch (Exception) when (_cts.IsCancellationRequested) { } // slopwatch-ignore: SW003 expected cancellation or I/O error during shutdown
+
+            // Drain any inbound bytes the consumer never read (and wait for the peer's FIN,
+            // bounded). Without this, closing a socket with unread receive-buffer data makes
+            // the OS emit RST instead of FIN, which the peer would surface as ErrorClosed
+            // ("connection reset by peer") instead of a clean PeerClosed/Closed.
+            DrainInboundForClose();
 
             // Close the stream and socket
             await _stream.DisposeAsync().ConfigureAwait(false);
             _socket.Close();
+        }
+
+        /// <summary>
+        /// Reads and discards inbound bytes until the peer's FIN (recv returns 0) or until a
+        /// byte/time cap is hit. Used only on the full-close path so the final socket close
+        /// produces a FIN rather than an RST. Operates directly on the socket because the
+        /// consumer-driven <see cref="PipeReader"/> has already been completed by this point.
+        /// </summary>
+        private void DrainInboundForClose()
+        {
+            // If the socket is already gone (e.g. peer reset, or a racing abort) there is
+            // nothing to drain — closing it will just be a no-op / already-RST'd connection.
+            byte[]? buffer = null;
+            try
+            {
+                var deadline = DateTime.UtcNow + DrainTimeout;
+                var drained = 0;
+
+                while (drained < DrainMaxBytes && DateTime.UtcNow < deadline)
+                {
+                    // Only block waiting for data if there might be more coming. Poll with a
+                    // short, bounded timeout so a quiet-but-not-yet-FIN peer can't hang close.
+                    var remaining = deadline - DateTime.UtcNow;
+                    if (remaining <= TimeSpan.Zero)
+                        break;
+
+                    // Poll returns true when the socket is readable; a readable socket that
+                    // yields 0 bytes from Receive means the peer has sent its FIN (EOF).
+                    var pollMicros = (int)Math.Min(remaining.TotalMilliseconds * 1000, int.MaxValue);
+                    if (!_socket.Poll(pollMicros, SelectMode.SelectRead))
+                        break; // no data and no FIN within the budget — stop draining
+
+                    buffer ??= ArrayPool<byte>.Shared.Rent(ReadBufferSize);
+                    int read;
+                    try
+                    {
+                        read = _socket.Receive(buffer, SocketFlags.None);
+                    }
+                    catch (SocketException) { break; } // slopwatch-ignore: SW003 peer reset/closed mid-drain — stop, close will be a no-op
+
+                    if (read == 0)
+                        break; // peer FIN observed — receive side fully drained
+
+                    drained += read;
+                }
+            }
+            catch (ObjectDisposedException) { } // slopwatch-ignore: SW003 socket disposed by a racing abort — nothing to drain
+            catch (SocketException) { } // slopwatch-ignore: SW003 connection already reset — nothing to drain
+            finally
+            {
+                if (buffer != null)
+                    ArrayPool<byte>.Shared.Return(buffer);
+            }
         }
 
         public void Abort()
@@ -153,10 +259,10 @@ namespace Akka.IO
             // Cancel pumps immediately
             _cts.Cancel();
 
-            // Complete pipes to unblock any pending reads/writes on them.
+            // Complete pipes/readers to unblock any pending reads/writes.
             // InvalidOperationException if already completed — safe to ignore.
             try { _outputPipe.Writer.Complete(); } catch (InvalidOperationException) { } // slopwatch-ignore: SW003 pipe may already be completed
-            try { _inputPipe.Writer.Complete(); } catch (InvalidOperationException) { } // slopwatch-ignore: SW003 pipe may already be completed
+            try { _inputReader.Complete(); } catch (Exception) { } // slopwatch-ignore: SW003 reader may already be completed / mid-read
 
             // RST the socket — SocketException/ObjectDisposedException if already closed.
             try
@@ -176,74 +282,19 @@ namespace Akka.IO
             _cts.Cancel();
 
             await _outputPipe.Writer.CompleteAsync().ConfigureAwait(false);
-            await _inputPipe.Writer.CompleteAsync().ConfigureAwait(false);
+            try { await _inputReader.CompleteAsync().ConfigureAwait(false); }
+            catch (Exception) { } // slopwatch-ignore: SW003 reader may have an in-flight read during disposal
 
-            // Wait for pump tasks — they may throw OperationCanceledException or I/O errors during shutdown.
+            // Wait for the write pump — it may throw OperationCanceledException or I/O errors during shutdown.
             try
             {
-                await Task.WhenAll(ReadCompleted, WriteCompleted).ConfigureAwait(false);
+                await WriteCompleted.ConfigureAwait(false);
             }
             catch (Exception) when (_cts.IsCancellationRequested) { } // slopwatch-ignore: SW003 expected errors during disposal
 
             await _stream.DisposeAsync().ConfigureAwait(false);
             _socket.Dispose();
             _cts.Dispose();
-        }
-
-        /* ================================================================= */
-        /*  Read pump: Stream → Input Pipe                                   */
-        /* ================================================================= */
-
-        private async Task RunReadPumpAsync(CancellationToken ct)
-        {
-            var writer = _inputPipe.Writer;
-            Exception? error = null;
-
-            try
-            {
-                while (!ct.IsCancellationRequested)
-                {
-                    var memory = writer.GetMemory();
-                    var bytesRead = await _stream.ReadAsync(memory, ct).ConfigureAwait(false);
-
-                    if (bytesRead == 0)
-                        break; // EOF — peer closed
-
-                    writer.Advance(bytesRead);
-
-                    var flushResult = await writer.FlushAsync(ct).ConfigureAwait(false);
-                    if (flushResult.IsCompleted || flushResult.IsCanceled)
-                        break; // Reader (actor) is done
-                }
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested) { } // slopwatch-ignore: SW003 normal CTS-driven shutdown
-            catch (Exception ex)
-            {
-                error = ex;
-            }
-            finally
-            {
-                // Set error fields BEFORE completing the pipe writer.
-                // This ensures the actor can synchronously check HasReadError
-                // when it handles the PipeReadCompleted with IsCompleted,
-                // even if the ReadPumpFailed message hasn't been processed yet.
-                if (error != null)
-                {
-                    Volatile.Write(ref _readError, error);
-                    Volatile.Write(ref _hasReadError, true);
-                }
-
-                // Complete the pipe writer WITHOUT passing the exception.
-                // This preserves buffered data so the actor can drain it before
-                // checking ReadCompleted.IsFaulted for the error.
-                await writer.CompleteAsync().ConfigureAwait(false);
-            }
-
-            // If there was an error, throw it so ReadCompleted.IsFaulted is true.
-            // This must happen AFTER the pipe writer is completed so buffered data
-            // is available for the actor to drain.
-            if (error != null)
-                throw error;
         }
 
         /* ================================================================= */

--- a/src/core/Akka/IO/TcpTransportConnection.cs
+++ b/src/core/Akka/IO/TcpTransportConnection.cs
@@ -19,14 +19,39 @@ namespace Akka.IO
 {
     /// <summary>
     /// Plaintext TCP implementation of <see cref="ITransportConnection"/>.
-    /// Owns an output pipe + write pump that bridge to a NetworkStream, and exposes a
+    /// Writes directly to a <see cref="NetworkStream"/> using a double-buffer
+    /// ping-pong (no output Pipe, no background write pump), and exposes a
     /// <see cref="PipeReader"/> for the inbound side that the consuming actor drives directly.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Write side — double-buffer ping-pong.</b> The owning <see cref="TcpConnection"/>
+    /// actor is the single writer: it pushes bytes in via <see cref="WriteUnflushed(ReadOnlyMemory{byte})"/>
+    /// and commits them with <see cref="FlushAsync"/>. There are two
+    /// <see cref="ArrayBufferWriter{T}"/> slots. New bytes accumulate into the <em>active</em>
+    /// slot; a flush hands the active slot to <see cref="Stream.WriteAsync(ReadOnlyMemory{byte},CancellationToken)"/>
+    /// and swaps to the other (already-drained) slot so the actor can keep batching the next
+    /// burst while the kernel transmits the previous one. The in-flight write is awaited only
+    /// just before a new one would start — that overlap is what replaces the old pump→Pipe→stream
+    /// cross-thread hand-off.
+    /// </para>
+    /// <para>
+    /// <b>Backpressure.</b> Memory is bounded to (at most) two buffered batches. If a flush
+    /// arrives while a write is already in flight, <see cref="FlushAsync"/> returns a not-yet-completed
+    /// <see cref="ValueTask{FlushResult}"/> that completes only once the in-flight write drains and the
+    /// newly-buffered batch has itself been handed to the stream — so a fast producer cannot pile up
+    /// unbounded bytes in user space.
+    /// </para>
+    /// </remarks>
     public sealed class TcpTransportConnection : ITransportConnection
     {
         // Segment size for the inbound StreamPipeReader. Large enough that one ReadAsync
         // typically pulls a full kernel receive buffer in a single call.
         private const int ReadBufferSize = 64 * 1024;
+
+        // Initial capacity of each outbound double-buffer slot. Grows on demand if a batch
+        // exceeds it; sized so the common small-message batch never reallocates.
+        private const int WriteBufferInitialCapacity = 8 * 1024;
 
         // Bounds for the drain-on-close. Closing a socket that still has unread inbound
         // data in the kernel receive buffer makes the OS emit RST instead of FIN, so the
@@ -39,14 +64,52 @@ namespace Akka.IO
 
         private readonly Socket _socket;
         private readonly Stream _stream;
-        private readonly PipeReader _inputReader;
-        private readonly Pipe _outputPipe;
+        private readonly ReadGate _inputReader;
         private readonly CancellationTokenSource _cts = new();
+
+        // ── Outbound double-buffer ping-pong ───────────────────────────────────
+        // Two slots: bytes accumulate into _buffers[_activeIdx]; on flush that slot is
+        // handed to _stream.WriteAsync and we swap to the other slot, so the actor can keep
+        // batching the next burst while the kernel transmits this one.
+        //
+        // CONCURRENCY: the owning TcpConnection actor is the single *producer* (it calls
+        // WriteUnflushed/FlushAsync from its own mailbox thread, fire-and-forget). But the
+        // completion of an in-flight _stream.WriteAsync runs on an arbitrary thread-pool /
+        // I/O thread, and that completion has to start the NEXT batch (otherwise a batch that
+        // landed in the standby slot while a write was in flight would never be sent until the
+        // actor happened to flush again — under load that wakeup is exactly what gets lost and
+        // the whole connection hangs). So both the actor thread and the write-completion
+        // continuation mutate the buffers / _activeIdx / _inflightWrite. ALL of those
+        // mutations are serialized under _writeGate; the buffer slots are never touched outside
+        // the lock. The write itself runs outside the lock — only the bookkeeping is guarded.
+        private readonly object _writeGate = new();
+
+        private readonly ArrayBufferWriter<byte>[] _buffers =
+        {
+            new(WriteBufferInitialCapacity),
+            new(WriteBufferInitialCapacity),
+        };
+
+        private int _activeIdx;
+
+        // The in-flight write of the OTHER (non-active) slot, or null if no write is in flight.
+        // Guarded by _writeGate. While non-null the slot it is transmitting (1 ^ _activeIdx)
+        // must not be touched; the active slot keeps accumulating the next batch.
+        private Task? _inflightWrite;
+
+        // Latches the first write error so subsequent flushes surface it instead of writing
+        // to a dead stream. WriteCompleted is completed (faulted) when this is set.
+        private readonly TaskCompletionSource<int> _writeCompletedTcs =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Guarded by _writeGate.
+        private bool _writeClosed;
+        private Exception? _writeError;
 
         /// <summary>
         /// Creates a transport connection from an already-connected socket.
-        /// Starts the write pump loop immediately; inbound reads are driven on demand
-        /// by the consumer via <see cref="Input"/>.
+        /// Inbound reads are driven on demand by the consumer via <see cref="Input"/>;
+        /// outbound writes go straight to the stream via the double-buffer.
         /// </summary>
         public TcpTransportConnection(Socket socket, PipeOptions? inputPipeOptions = null,
             PipeOptions? outputPipeOptions = null)
@@ -56,15 +119,20 @@ namespace Akka.IO
 
             // Inbound: no background read pump. The consumer (TcpConnection actor) drives
             // PipeReader.ReadAsync directly, so a socket read runs on the consumer's own
-            // continuation instead of being flushed across a Pipe to a second thread — this
-            // removes the pump→Pipe→consumer cross-thread hand-off (one fewer thread-pool
-            // dispatch per chunk). inputPipeOptions (readerScheduler etc.) is intentionally
-            // unused now that there is no Pipe on the read side.
-            _inputReader = PipeReader.Create(_stream, new StreamPipeReaderOptions(bufferSize: ReadBufferSize, leaveOpen: true));
-            _outputPipe = new Pipe(outputPipeOptions ?? PipeOptions.Default);
+            // continuation instead of being flushed across a Pipe to a second thread. The
+            // inputPipeOptions / outputPipeOptions parameters are retained for source/binary
+            // compatibility but are unused now that neither side owns a Pipe.
+            //
+            // The reader is wrapped in a ReadGate so the close/abort/dispose paths can quiesce
+            // any in-flight consumer ReadAsync BEFORE completing the underlying StreamPipeReader.
+            // Completing a StreamPipeReader concurrently with an in-flight read resets the
+            // segment whose End the resuming read is about to write, throwing
+            // ArgumentOutOfRangeException out of BufferSegment.set_End (see ReadGate).
+            _inputReader = new ReadGate(
+                PipeReader.Create(_stream, new StreamPipeReaderOptions(bufferSize: ReadBufferSize, leaveOpen: true)));
 
             ReadCompleted = Task.CompletedTask;
-            WriteCompleted = RunWritePumpAsync(_cts.Token);
+            WriteCompleted = _writeCompletedTcs.Task;
         }
 
         /// <summary>
@@ -77,12 +145,13 @@ namespace Akka.IO
             _stream = stream;
 
             // See the socket-only constructor: the inbound side is a consumer-driven
-            // PipeReader, not a background pump + Pipe.
-            _inputReader = PipeReader.Create(_stream, new StreamPipeReaderOptions(bufferSize: ReadBufferSize, leaveOpen: true));
-            _outputPipe = new Pipe(outputPipeOptions ?? PipeOptions.Default);
+            // PipeReader (wrapped in a ReadGate for safe close) and the outbound side is a
+            // direct double-buffer, so there is no Pipe.
+            _inputReader = new ReadGate(
+                PipeReader.Create(_stream, new StreamPipeReaderOptions(bufferSize: ReadBufferSize, leaveOpen: true)));
 
             ReadCompleted = Task.CompletedTask;
-            WriteCompleted = RunWritePumpAsync(_cts.Token);
+            WriteCompleted = _writeCompletedTcs.Task;
         }
 
         public PipeReader Input => _inputReader;
@@ -104,15 +173,33 @@ namespace Akka.IO
 
         internal void WriteUnflushed(ReadOnlyMemory<byte> data)
         {
-            _outputPipe.Writer.Write(data.Span);
+            // Guard the buffer + _activeIdx: a write-completion continuation may concurrently
+            // swap _activeIdx and clear a slot, so appends must be serialized with it.
+            lock (_writeGate)
+            {
+                if (_writeClosed)
+                    return; // writer side already shut down — drop (the actor sees the failure via WriteCompleted)
+
+                _buffers[_activeIdx].Write(data.Span);
+            }
         }
 
         internal void WriteUnflushed(ReadOnlySequence<byte> data)
         {
-            var writer = _outputPipe.Writer;
-            foreach (var segment in data)
+            lock (_writeGate)
             {
-                writer.Write(segment.Span);
+                if (_writeClosed)
+                    return;
+
+                var active = _buffers[_activeIdx];
+                if (data.IsSingleSegment)
+                {
+                    active.Write(data.FirstSpan);
+                    return;
+                }
+
+                foreach (var segment in data)
+                    active.Write(segment.Span);
             }
         }
 
@@ -128,9 +215,242 @@ namespace Akka.IO
             return FlushAsync(ct);
         }
 
+        /// <summary>
+        /// Commits whatever has accumulated in the active buffer to the stream.
+        /// If no write is in flight, it starts one for the active slot and swaps to the drained
+        /// slot, so the actor can keep batching the next burst while the kernel transmits this
+        /// one. If a write is already in flight, the freshly-buffered bytes simply stay in the
+        /// (standby) active slot: the in-flight write's completion continuation picks them up and
+        /// starts the next write itself (see <see cref="OnWriteCompleted"/>), so the batch is
+        /// always drained without a second flush from the actor. Memory stays bounded to two
+        /// batches and the call always returns synchronously — the caller (the actor) fires
+        /// flushes and discards the result; liveness is owned by the internal write chain.
+        /// </summary>
         public ValueTask<FlushResult> FlushAsync(CancellationToken ct = default)
         {
-            return _outputPipe.Writer.FlushAsync(ct);
+            if (ct.IsCancellationRequested)
+                return new ValueTask<FlushResult>(new FlushResult(isCanceled: true, isCompleted: false));
+
+            // All double-buffer bookkeeping is serialized here against the write-completion
+            // continuation (OnWriteCompleted), which runs on an arbitrary thread.
+            lock (_writeGate)
+            {
+                // If the writer side already failed/closed, report it (IsCompleted = true) so the
+                // caller stops pushing. We never throw out of the hot flush path.
+                if (_writeClosed)
+                    return new ValueTask<FlushResult>(new FlushResult(isCanceled: false, isCompleted: true));
+
+                // A write is already in flight: leave the bytes in the standby slot. When the
+                // in-flight write completes, OnWriteCompleted will start them. Nothing to do now.
+                if (_inflightWrite != null)
+                    return new ValueTask<FlushResult>(new FlushResult(isCanceled: false, isCompleted: false));
+
+                // Nothing in flight — start the active batch (if any) right now.
+                if (_buffers[_activeIdx].WrittenCount > 0)
+                    StartActiveWriteLocked(ct);
+
+                return new ValueTask<FlushResult>(new FlushResult(isCanceled: false, isCompleted: false));
+            }
+        }
+
+        /// <summary>
+        /// Starts the stream write for the active buffer (which must be non-empty), stores it as
+        /// the in-flight write, swaps the active index to the now-idle slot, and attaches a
+        /// completion continuation that chains the next batch. MUST be called while holding
+        /// <see cref="_writeGate"/>, and only when no write is already in flight.
+        /// </summary>
+        private void StartActiveWriteLocked(CancellationToken ct)
+        {
+            var slot = _activeIdx;
+            var active = _buffers[slot];
+
+            // Hold the write as a Task so the completion continuation can chain off it.
+            // .AsTask() boxes the ValueTask once. NetworkStream/SslStream flush per WriteAsync,
+            // so no explicit Flush is needed.
+            var writeTask = _stream.WriteAsync(active.WrittenMemory, ct).AsTask();
+            _inflightWrite = writeTask;
+
+            // Swap: the next batch fills the OTHER slot. The slot we just handed off (now the
+            // standby) stays untouched until OnWriteCompleted observes its write finishing.
+            _activeIdx ^= 1;
+
+            // Clear the slot we are about to start filling. Its previous write already completed
+            // (we never reuse a slot whose write is still in flight), so this is safe.
+            _buffers[_activeIdx].Clear();
+
+            // When this write finishes, drive the chain forward (start the standby batch, surface
+            // faults). Runs on the completing thread, but everything it touches is under the lock.
+            writeTask.ContinueWith(
+                static (t, state) => ((TcpTransportConnection)state!).OnWriteCompleted(t),
+                this,
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+
+        /// <summary>
+        /// Continuation invoked when an in-flight write completes. Clears the just-finished
+        /// write, surfaces any fault, and — if the actor accumulated another batch in the
+        /// standby slot while this write was on the wire — starts that batch, keeping the write
+        /// chain alive without requiring a fresh flush from the actor. This is what guarantees a
+        /// buffered batch is never stranded (the missed-wakeup hang the double-buffer regressed).
+        /// </summary>
+        private void OnWriteCompleted(Task completed)
+        {
+            lock (_writeGate)
+            {
+                // Stale continuation (e.g. after close/abort replaced or cleared the field): ignore.
+                if (!ReferenceEquals(_inflightWrite, completed))
+                {
+                    _ = completed.Exception; // observe to avoid UnobservedTaskException
+                    return;
+                }
+
+                _inflightWrite = null;
+
+                if (completed.IsFaulted)
+                {
+                    FailWriteLocked(completed.Exception?.GetBaseException() ?? new IOException("TCP write failed"));
+                    return;
+                }
+
+                // Once draining/closed, DrainPendingWritesAsync owns the remaining writes — do
+                // not self-chain (it awaits _inflightWrite, which we have just nulled).
+                if (completed.IsCanceled || _writeClosed || _draining)
+                    return;
+
+                // The actor may have buffered another batch in the (now) active slot while this
+                // write was transmitting. Start it so the chain keeps draining.
+                if (_buffers[_activeIdx].WrittenCount > 0)
+                    StartActiveWriteLocked(_cts.Token);
+            }
+        }
+
+        /// <summary>
+        /// Awaits the final in-flight write plus any bytes still sitting in the buffers, so that
+        /// every byte the actor handed us reaches the socket before we send FIN / close.
+        /// Replaces the old "await WriteCompleted (pump drains)" step now that there is no pump.
+        /// </summary>
+        /// <remarks>
+        /// The actor has already flushed all pending writes before calling close, so no new bytes
+        /// arrive once we are here. We close the producer side (so the self-chaining continuation
+        /// stops starting writes and hands control to us), then loop: grab the in-flight write
+        /// under the lock, await it outside the lock, and write any buffered tail — until both
+        /// slots are empty and nothing is in flight.
+        /// </remarks>
+        private async Task DrainPendingWritesAsync()
+        {
+            try
+            {
+                // Take ownership of the write chain: stop OnWriteCompleted from starting new
+                // writes so we can drain deterministically. _writeClosed is set only at the very
+                // end (CompleteWrite); this DrainingClosed handshake is the interim guard.
+                Task? inflight;
+                lock (_writeGate)
+                {
+                    _draining = true;
+                    inflight = _inflightWrite;
+                }
+
+                while (true)
+                {
+                    // Finish whatever is on the wire (outside the lock).
+                    if (inflight != null)
+                        await inflight.ConfigureAwait(false);
+
+                    byte[]? tail = null;
+                    int slot;
+                    lock (_writeGate)
+                    {
+                        _inflightWrite = null;
+
+                        slot = _activeIdx;
+                        var active = _buffers[slot];
+                        if (active.WrittenCount == 0)
+                            break; // nothing left in flight or buffered — done
+
+                        // Copy the tail out so we can write it outside the lock without it being
+                        // mutated, then clear the slot.
+                        tail = active.WrittenMemory.ToArray();
+                        active.Clear();
+                    }
+
+                    await _stream.WriteAsync(tail.AsMemory(), _cts.Token).ConfigureAwait(false);
+                    inflight = null; // loop to re-check for any further buffered bytes
+                }
+
+                CompleteWrite(null);
+            }
+            catch (OperationCanceledException) when (_cts.IsCancellationRequested)
+            {
+                // slopwatch-ignore: SW003 shutdown raced an abort — treat as a clean write completion
+                CompleteWrite(null);
+            }
+            catch (Exception ex)
+            {
+                CompleteWrite(ex);
+            }
+        }
+
+        /// <summary>
+        /// Attaches a benign continuation to the in-flight write (if any) so that, when an
+        /// <see cref="Abort"/> RSTs the socket and faults the write, it is observed rather than
+        /// surfacing later as an unobserved <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </summary>
+        private void ObserveInflightWrite()
+        {
+            Task? inflight;
+            lock (_writeGate)
+            {
+                inflight = _inflightWrite;
+            }
+
+            if (inflight is null || inflight.IsCompleted)
+            {
+                // Already done — touch its exception (if faulted) so it is marked observed.
+                _ = inflight?.Exception;
+                return;
+            }
+
+            inflight.ContinueWith(
+                static t => { _ = t.Exception; }, // slopwatch-ignore: SW003 fault is expected when the abort RSTs the socket
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+
+        // Set under _writeGate at the start of a drain-on-close so OnWriteCompleted stops
+        // self-chaining and hands the remaining writes to DrainPendingWritesAsync.
+        private bool _draining;
+
+        private void FailWriteLocked(Exception ex)
+        {
+            // Caller already holds _writeGate.
+            _writeError ??= ex;
+            CompleteWriteLocked(ex);
+        }
+
+        private void CompleteWrite(Exception? error)
+        {
+            lock (_writeGate)
+            {
+                CompleteWriteLocked(error);
+            }
+        }
+
+        private void CompleteWriteLocked(Exception? error)
+        {
+            // Caller holds _writeGate.
+            if (_writeClosed)
+                return;
+
+            _writeClosed = true;
+            _inflightWrite = null;
+
+            if (error != null)
+                _writeCompletedTcs.TrySetException(error);
+            else
+                _writeCompletedTcs.TrySetResult(0);
         }
 
         public async Task ShutdownAsync()
@@ -138,14 +458,11 @@ namespace Akka.IO
             // Tcp.ConfirmedClose: this is a HALF close. Flush our pending writes, then send
             // FIN (Shutdown(Send)) but leave the read side open. The consuming actor keeps
             // driving the inbound PipeReader until it observes the peer's FIN (EOF), at which
-            // point it finalizes the close. We must NOT drain here — that inbound data still
+            // point it finalizes the close. We must NOT drain inbound here — that data still
             // belongs to the consumer.
 
-            // Complete the output pipe — write pump will drain and exit
-            await _outputPipe.Writer.CompleteAsync().ConfigureAwait(false);
-
-            // Wait for write pump to finish flushing
-            await WriteCompleted.ConfigureAwait(false);
+            // Flush all buffered + in-flight writes so every byte reaches the socket before FIN.
+            await DrainPendingWritesAsync().ConfigureAwait(false);
 
             // Half-close the socket (send FIN).
             // SocketException is expected if the peer already reset the connection.
@@ -163,11 +480,8 @@ namespace Akka.IO
             // still-buffered inbound bytes so the OS sends FIN (not RST) on the final close,
             // then tear everything down.
 
-            // Complete the output pipe — write pump will drain and exit
-            await _outputPipe.Writer.CompleteAsync().ConfigureAwait(false);
-
-            // Wait for write pump to finish flushing
-            await WriteCompleted.ConfigureAwait(false);
+            // Flush all buffered + in-flight writes so every byte reaches the socket before FIN.
+            await DrainPendingWritesAsync().ConfigureAwait(false);
 
             // Send our FIN now (half-close the send side). Doing this before the drain lets
             // the peer observe our orderly shutdown and reciprocate while we read out whatever
@@ -180,11 +494,17 @@ namespace Akka.IO
             catch (SocketException) { } // slopwatch-ignore: SW003 socket may already be closed by peer or abort
             catch (ObjectDisposedException) { } // slopwatch-ignore: SW003 socket may already be disposed by an abort
 
-            // Cancel to unblock the write pump; the inbound reader is consumer-driven,
-            // so completing it releases any pooled buffers and frees the underlying stream
-            // for the bounded socket-level drain below.
+            // Cancel any straggling write/flush; the inbound reader is consumer-driven, so
+            // completing it releases pooled buffers and frees the underlying stream for the
+            // bounded socket-level drain below.
             _cts.Cancel();
-            try { _inputReader.Complete(); } catch (Exception) { } // slopwatch-ignore: SW003 reader may have an in-flight read during teardown
+
+            // Quiesce the consumer's in-flight ReadAsync (cancel it and wait for it to settle)
+            // BEFORE completing the underlying StreamPipeReader. Completing it while a read is
+            // mid-flight resets the segment the resuming read writes into, throwing
+            // ArgumentOutOfRangeException from BufferSegment.set_End — surfaced to the peer as a
+            // spurious ErrorClosed. Serializing the two closes that race window.
+            await _inputReader.QuiesceAndCompleteAsync().ConfigureAwait(false);
 
             // Wait for read completion — no background pump, so this is already complete.
             try { await ReadCompleted.ConfigureAwait(false); }
@@ -256,12 +576,19 @@ namespace Akka.IO
 
         public void Abort()
         {
-            // Cancel pumps immediately
+            // Cancel any pending write/flush immediately.
             _cts.Cancel();
 
-            // Complete pipes/readers to unblock any pending reads/writes.
-            // InvalidOperationException if already completed — safe to ignore.
-            try { _outputPipe.Writer.Complete(); } catch (InvalidOperationException) { } // slopwatch-ignore: SW003 pipe may already be completed
+            // Observe any in-flight write before we mark the write side closed — RSTing the
+            // socket below will fault it, and nobody else awaits it on the Abort path.
+            ObserveInflightWrite();
+
+            // Mark the write side closed so no further bytes are buffered, and complete
+            // WriteCompleted (no exception — Abort is an intentional RST, not an I/O failure).
+            CompleteWrite(null);
+
+            // Complete the inbound reader to unblock any pending read.
+            // Exception if already completed / mid-read — safe to ignore.
             try { _inputReader.Complete(); } catch (Exception) { } // slopwatch-ignore: SW003 reader may already be completed / mid-read
 
             // RST the socket — SocketException/ObjectDisposedException if already closed.
@@ -281,63 +608,256 @@ namespace Akka.IO
         {
             _cts.Cancel();
 
-            await _outputPipe.Writer.CompleteAsync().ConfigureAwait(false);
+            // Capture any in-flight write BEFORE we mark the write side closed (CompleteWrite
+            // nulls the field) so we can still settle it below and not dispose the stream out
+            // from under it.
+            Task? inflight;
+            lock (_writeGate)
+            {
+                inflight = _inflightWrite;
+                CompleteWriteLocked(null);
+            }
+
             try { await _inputReader.CompleteAsync().ConfigureAwait(false); }
             catch (Exception) { } // slopwatch-ignore: SW003 reader may have an in-flight read during disposal
 
-            // Wait for the write pump — it may throw OperationCanceledException or I/O errors during shutdown.
-            try
+            // Best-effort: let any in-flight write settle so we don't dispose the stream out
+            // from under it. It may throw OperationCanceledException / I/O errors during shutdown.
+            if (inflight != null)
             {
-                await WriteCompleted.ConfigureAwait(false);
+                try { await inflight.ConfigureAwait(false); }
+                catch (Exception) when (_cts.IsCancellationRequested) { } // slopwatch-ignore: SW003 expected errors during disposal
+                catch (Exception) { } // slopwatch-ignore: SW003 in-flight write failed during disposal — closing anyway
             }
-            catch (Exception) when (_cts.IsCancellationRequested) { } // slopwatch-ignore: SW003 expected errors during disposal
 
             await _stream.DisposeAsync().ConfigureAwait(false);
             _socket.Dispose();
             _cts.Dispose();
         }
 
-        /* ================================================================= */
-        /*  Write pump: Output Pipe → Stream                                 */
-        /* ================================================================= */
-
-        private async Task RunWritePumpAsync(CancellationToken ct)
+        /// <summary>
+        /// A <see cref="PipeReader"/> decorator that serializes <see cref="Complete"/> /
+        /// <see cref="CompleteAsync"/> against an in-flight consumer <see cref="ReadAsync"/> on the
+        /// wrapped <c>StreamPipeReader</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The inbound side is consumer-driven (no read pump): the owning
+        /// <see cref="TcpConnection"/> actor keeps a <see cref="ReadAsync"/> in flight on this
+        /// reader. A <c>StreamPipeReader</c> is <b>not</b> safe to <see cref="PipeReader.Complete"/>
+        /// while a read is in flight — <see cref="PipeReader.Complete"/> resets the
+        /// <c>BufferSegment</c> the resuming read is about to commit bytes into, so the read's
+        /// continuation does <c>segment.End += bytesRead</c> against a zero-length segment and
+        /// throws <see cref="ArgumentOutOfRangeException"/> out of <c>BufferSegment.set_End</c>.
+        /// That surfaces to the actor as an I/O error and, to the peer, as a spurious
+        /// <c>ErrorClosed</c> on an otherwise graceful close.
+        /// </para>
+        /// <para>
+        /// This gate closes that window. <see cref="ReadAsync"/> publishes the in-flight read (and a
+        /// per-read CTS linked to the caller's token). The teardown paths first
+        /// <em>quiesce</em> that read — cancel it and wait for it to observably finish — and only
+        /// then complete the underlying reader, so <see cref="PipeReader.Complete"/> can never run
+        /// concurrently with a read. The synchronous <see cref="Complete"/> (used by the abort path,
+        /// which must not block) defers the underlying complete to the in-flight read's own
+        /// continuation when a read is in flight, achieving the same serialization without awaiting.
+        /// </para>
+        /// </remarks>
+        private sealed class ReadGate : PipeReader
         {
-            var reader = _outputPipe.Reader;
-            Exception? error = null;
+            private readonly PipeReader _inner;
+            private readonly object _sync = new();
 
-            try
+            // The in-flight consumer ReadAsync, or null when no read is outstanding. Tracked so the
+            // teardown paths can cancel it and wait for it to settle before completing _inner.
+            private Task? _inflightRead;
+
+            // Cancels the in-flight ReadAsync so it unblocks promptly when we tear down.
+            private CancellationTokenSource? _readCts;
+
+            // Set once a teardown asked to complete the reader. Latched so a single completion wins
+            // and a deferred (read-in-flight) completion knows to run once the read settles.
+            private bool _completeRequested;
+            private Exception? _completeError;
+            private bool _innerCompleted;
+
+            public ReadGate(PipeReader inner) => _inner = inner;
+
+            public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
             {
-                while (!ct.IsCancellationRequested)
+                CancellationTokenSource linked;
+                Task<ReadResult> read;
+                lock (_sync)
                 {
-                    var readResult = await reader.ReadAsync(ct).ConfigureAwait(false);
-                    var buffer = readResult.Buffer;
+                    // If a teardown already completed (or requested completion of) the reader, do
+                    // not start a new socket read — surface a completed/canceled result instead.
+                    if (_completeRequested)
+                        return new ReadResult(default, isCanceled: true, isCompleted: true);
 
-                    if (buffer.Length > 0)
+                    _readCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    linked = _readCts;
+                    read = _inner.ReadAsync(linked.Token).AsTask();
+                    _inflightRead = read;
+                }
+
+                try
+                {
+                    return await read.ConfigureAwait(false);
+                }
+                finally
+                {
+                    bool runDeferredComplete;
+                    Exception? deferredError;
+                    lock (_sync)
                     {
-                        // Write each contiguous segment to the stream.
-                        // Pipe segments are typically large (4KB+), so this is
-                        // usually 1 WriteAsync call per ReadAsync wake-up.
-                        foreach (var segment in buffer)
-                        {
-                            await _stream.WriteAsync(segment, ct).ConfigureAwait(false);
-                        }
+                        if (ReferenceEquals(_inflightRead, read))
+                            _inflightRead = null;
+                        linked.Dispose();
+                        if (ReferenceEquals(_readCts, linked))
+                            _readCts = null;
+
+                        // A synchronous Complete() that arrived while this read was in flight
+                        // deferred the underlying complete to us — run it now that the read has
+                        // settled and no read is outstanding.
+                        runDeferredComplete = _completeRequested && !_innerCompleted && _inflightRead == null;
+                        deferredError = _completeError;
+                        if (runDeferredComplete)
+                            _innerCompleted = true;
                     }
 
-                    reader.AdvanceTo(buffer.End);
-
-                    if (readResult.IsCompleted)
-                        break; // Writer (actor) completed the pipe
+                    if (runDeferredComplete)
+                        CompleteInnerSafely(deferredError);
                 }
             }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested) { } // slopwatch-ignore: SW003 normal CTS-driven shutdown
-            catch (Exception ex)
+
+            public override bool TryRead(out ReadResult result)
             {
-                error = ex;
+                lock (_sync)
+                {
+                    if (_completeRequested)
+                    {
+                        result = new ReadResult(default, isCanceled: true, isCompleted: true);
+                        return true;
+                    }
+                }
+
+                return _inner.TryRead(out result);
             }
-            finally
+
+            public override void AdvanceTo(SequencePosition consumed) => _inner.AdvanceTo(consumed);
+
+            public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
+                => _inner.AdvanceTo(consumed, examined);
+
+            public override void CancelPendingRead()
             {
-                await reader.CompleteAsync(error).ConfigureAwait(false);
+                CancellationTokenSource? cts;
+                lock (_sync)
+                {
+                    cts = _readCts;
+                }
+
+                if (cts != null)
+                {
+                    try { cts.Cancel(); }
+                    catch (ObjectDisposedException) { } // slopwatch-ignore: SW003 read already settled and disposed its CTS
+                }
+
+                _inner.CancelPendingRead();
+            }
+
+            /// <summary>
+            /// Cancels the in-flight read (if any), waits for it to settle, then completes the
+            /// underlying reader. The teardown paths call this so <see cref="PipeReader.Complete"/>
+            /// never runs concurrently with a read.
+            /// </summary>
+            public async Task QuiesceAndCompleteAsync(Exception? exception = null)
+            {
+                Task? inflight;
+                CancellationTokenSource? cts;
+                lock (_sync)
+                {
+                    if (_innerCompleted)
+                        return;
+
+                    _completeRequested = true;
+                    _completeError ??= exception;
+                    inflight = _inflightRead;
+                    cts = _readCts;
+
+                    // No read in flight: complete now under the same lock-ordering as the deferred
+                    // path so the two never both complete _inner.
+                    if (inflight == null)
+                        _innerCompleted = true;
+                }
+
+                if (inflight == null)
+                {
+                    CompleteInnerSafely(exception);
+                    return;
+                }
+
+                // Cancel the in-flight read so it unblocks promptly, then wait for it to settle.
+                // The read's own continuation may complete _inner (the deferred path); whichever of
+                // us observes _inflightRead == null && !_innerCompleted does the completion.
+                if (cts != null)
+                {
+                    try { cts.Cancel(); }
+                    catch (ObjectDisposedException) { } // slopwatch-ignore: SW003 read already settled and disposed its CTS
+                }
+
+                try { await inflight.ConfigureAwait(false); }
+                catch (Exception) { } // slopwatch-ignore: SW003 the read we just cancelled is expected to cancel/fault
+
+                bool completeNow;
+                lock (_sync)
+                {
+                    completeNow = !_innerCompleted;
+                    if (completeNow)
+                        _innerCompleted = true;
+                }
+
+                if (completeNow)
+                    CompleteInnerSafely(exception);
+            }
+
+            public override void Complete(Exception? exception = null)
+            {
+                CancellationTokenSource? cts;
+                bool completeNow;
+                lock (_sync)
+                {
+                    if (_innerCompleted)
+                        return;
+
+                    _completeRequested = true;
+                    _completeError ??= exception;
+                    cts = _readCts;
+
+                    // If a read is in flight, DO NOT complete _inner here — that is the exact
+                    // corruption. Cancel the read and let its continuation (in ReadAsync's finally)
+                    // complete _inner once it settles. If no read is in flight, complete now.
+                    completeNow = _inflightRead == null;
+                    if (completeNow)
+                        _innerCompleted = true;
+                }
+
+                if (cts != null)
+                {
+                    try { cts.Cancel(); }
+                    catch (ObjectDisposedException) { } // slopwatch-ignore: SW003 read already settled and disposed its CTS
+                }
+
+                if (completeNow)
+                    CompleteInnerSafely(exception);
+            }
+
+            public override ValueTask CompleteAsync(Exception? exception = null)
+                => new(QuiesceAndCompleteAsync(exception));
+
+            private void CompleteInnerSafely(Exception? exception)
+            {
+                try { _inner.Complete(exception); }
+                catch (Exception) { } // slopwatch-ignore: SW003 underlying reader may already be completed
             }
         }
     }


### PR DESCRIPTION
## What this does

Removes **both** background pumps from `Akka.IO`'s `TcpTransportConnection`:
- **Read:** the input `Pipe` + `RunReadPumpAsync` → consumer-driven `PipeReader.Create(stream)` (the `TcpConnection` actor drives `ReadAsync` directly). Removes the pump→Pipe→consumer cross-thread hand-off (one fewer thread-pool dispatch per inbound chunk).
- **Write:** the output `Pipe` + `RunWritePumpAsync` → a lock-guarded double-buffer ping-pong (fill one `ArrayBufferWriter` while the other is in-flight) — keeps coalescing/overlap without the output-pipe→pump hop.

Default Akka.IO behavior is preserved (clean `PeerClosed`/`Closed` vs `ErrorClosed`); the pumps' eager draining was load-bearing for clean FIN-not-RST close, so `CloseAsync` now does a bounded drain-on-close.

## Benchmark figures

**Isolated Akka.IO TCP** (`TcpOperationsBenchmarks`, net10.0, Ryzen 9 9900X, 100-byte msgs) — the headline mechanical win:

| clients | before (pumps) | after (no pumps) | Δ |
|---|---|---|---|
| **1** | 1,057 ns · 946K req/s | **749 ns · 1.34M req/s** | **−29% latency / +41% throughput** |

The win is a per-message latency reduction (removing a thread hop), so it's largest at low concurrency and tapers as the link saturates.

**Full remote path** (`RemotePingPong`, streams transport, both pumps removed):
- **Context switches −69%** (14M → 4.4M; involuntary 6.9M → 1.9M), CPU ~19 → ~17.5 cores.
- **Gap to DotNetty: ~6% → parity** at the saturation peak, and **+22–79% ahead at low/mid concurrency** (1–10 clients).
- Unbiased peak (N=5, tight settle): streams median 1.58M vs DotNetty 1.51M — *caveat:* DotNetty ran at higher residual load in the interleave, so read this as **≈parity-to-slightly-ahead at peak**, with the robust win being low-concurrency latency.

## ⚠️ Status: DRAFT — known concurrent-close deadlock

This hangs under **many concurrent connection closes**. Repro: `TcpOperationsBenchmarks` at `ClientsCount=10`/`30` → `Benchmark timed out` (60s), zero iterations, processes blocked at ~0% CPU. `ClientsCount=1` is fine; the read-only-pump-removal build does **not** hang.

**This is the bit to review.** It survives the existing single-connection gate + `TcpConcurrentWriteSpec` (16 conns, sustained writes, *no close*) + `TcpGracefulCloseRaceSpec` (100 *sequential* closes) — the gap is **concurrent close of many connections**, which nothing currently tests.

<details>
<summary>Our root cause (proven via full process dump + SOS) — expand after you've had a look</summary>

The `ReadGate` decorator stops tracking the read the moment `_inner.ReadAsync` **returns**, but the consumer (`TcpConnection.ReadPipeChunkAsync`) keeps using that `ReadResult.Buffer` **outside the gate** (`buffer.CopyTo(array)`). Under concurrent close:

1. `ReadAsync` returns → gate sets `_inflightRead = null`.
2. `CloseAsync` → `QuiesceAndCompleteAsync` sees no in-flight read → `_inner.Complete()` → **recycles the `BufferSegment`s the consumer is mid-copy on**.
3. Consumer's `buffer.CopyTo` → `ArgumentOutOfRangeException (Parameter 'start')`.
4. AORE isn't in `IsOwnShutdownFault`'s allow-list → `IoTaskFailed` → `DoCloseConnection(ErrorClosed(...))`.
5. The peer only handles `Tcp.Closed`; `ErrorClosed` is a **sibling** `ConnectionClosed` and `ConnectionClosed : IDeadLetterSuppression` → it's dropped **silently** → one connection never reports done → the coordinating `Ask` hangs forever.

Dump confirms: the stranded connection's `ClosedEvent` is literally `ErrorClosed("...(Parameter 'start')")`, coordinator stuck at 9/10 children.

**Proposed fix:** copy the buffer **inside** the `ReadGate` (return a segment-independent `ReadResult`) so `Complete()` can't recycle a buffer the consumer still holds; plus add `ArgumentOutOfRangeException` to `IsOwnShutdownFault` as defense-in-depth. Needs a deterministic concurrent-close-of-N-connections regression test.
</details>

@Aaronontheweb — you're the concurrency expert; curious whether you concur with that diagnosis or see a cleaner fix.

*(Branch sits on the streams-transport base, hence the fork-internal `io-pr-base` target — the read-pump commit cherry-picks clean onto `dev`, but the write-side commit conflicts there, so this is a review vehicle, not a dev-merge candidate yet.)*
